### PR TITLE
build: include web in dist target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -55,6 +55,7 @@ dist-hook:
 	  --exclude="configure.lineno" --exclude="configure.status.lineno" \
 	  -f - $$subdir | (cd $(distdir) && tar -xf -)\
 	done;
+	tar -c --exclude ".git*" -f - web | (cd $(distdir) && tar -xf -)
 	touch $(distdir)/Makefile.am
 	find $(distdir) -exec touch -r $(distdir)/Makefile.am {} \;
 


### PR DESCRIPTION
allow make dist-gzip to generate a package that includes the
web frontend as documented
