### PR TITLE
RFC: Add 'write_rrds' option for disabling rrds

### DIFF
--- a/gmetad/conf.c.in
+++ b/gmetad/conf.c.in
@@ -230,11 +230,20 @@ static DOTCONF_CB(cb_setuid)
 }
 
 static DOTCONF_CB(cb_scalable)
-{  
+{
    gmetad_config_t *c = (gmetad_config_t*) cmd->option->info;
    debug_msg("Setting scalable = %s", cmd->data.str);
    if (!strcmp(cmd->data.str, "off"))
       c->scalable_mode = 0;
+   return NULL;
+}
+
+static DOTCONF_CB(cb_write_rrds)
+{
+   gmetad_config_t *c = (gmetad_config_t*) cmd->option->info;
+   debug_msg("Setting write_rrds = %s", cmd->data.str);
+   if (!strcmp(cmd->data.str, "off"))
+       c->write_rrds = cmd->data.value;
    return NULL;
 }
 
@@ -299,6 +308,7 @@ static configoption_t gmetad_options[] =
       {"setuid", ARG_TOGGLE, cb_setuid, &gmetad_config, 0},
       {"setuid_username", ARG_STR, cb_setuid_username, &gmetad_config, 0},
       {"scalable", ARG_STR, cb_scalable, &gmetad_config, 0},
+      {"write_rrds", ARG_STR, cb_write_rrds, &gmetad_config, 0},
       {"RRAs", ARG_LIST, cb_RRAs, &gmetad_config, 0},
       {"case_sensitive_hostnames", ARG_INT, cb_case_sensitive_hostnames, &gmetad_config, 0},
       {"carbon_server", ARG_STR, cb_carbon_server, &gmetad_config, 0},
@@ -322,6 +332,7 @@ set_defaults (gmetad_config_t *config)
    config->should_setuid = 1;
    config->setuid_username = "nobody";
    config->rrd_rootdir = "@varstatedir@/ganglia/rrds";
+   config->write_rrds = 1;
    config->scalable_mode = 1;
    config->all_trusted = 0;
    config->num_RRAs = 3;

--- a/gmetad/conf.h
+++ b/gmetad/conf.h
@@ -22,6 +22,7 @@ typedef struct
       int carbon_timeout;
       char *graphite_prefix;
       int scalable_mode;
+      int write_rrds;
       int all_trusted;
       int num_RRAs;
       char *RRAs[MAX_RRAS];

--- a/gmetad/gmetad.c
+++ b/gmetad/gmetad.c
@@ -240,7 +240,10 @@ write_root_summary(datum_t *key, datum_t *val, void *arg)
 
    /* err_msg("Writing Overall Summary for metric %s (%s)", name, sum); */
 
-   /* Save the data to a round robin database */
+   /* Save the data to a rrd file unless write_rrds == off */
+	 if (gmetad_config.write_rrds == 0)
+	     return 0;
+
    rc = write_data_to_rrd( NULL, NULL, name, sum, num, 15, 0, metric->slope);
    if (rc)
       {
@@ -449,7 +452,7 @@ main ( int argc, char *argv[] )
 
          /* Save them to RRD */
          hash_foreach(root.metric_summary, write_root_summary, NULL);
-         
+
          /* Remember our last run */
          last_metadata = apr_time_now();
       }

--- a/gmetad/process_xml.c
+++ b/gmetad/process_xml.c
@@ -568,7 +568,7 @@ startElement_HOSTS(void *data, const char *el, const char **attr)
       }
    return 0;
 }
-               
+
 
 static int
 startElement_METRIC(void *data, const char *el, const char **attr)
@@ -588,7 +588,7 @@ startElement_METRIC(void *data, const char *el, const char **attr)
    hash_t *summary;
    Metric_t *metric;
 
-   if (!xmldata->host_alive) return 0;
+   if (!xmldata->host_alive || gmetad_config.write_rrds != 1) return 0;
 
    /* Get name for hash key, and val/type for summaries. */
    for(i = 0; attr[i]; i+=2)
@@ -1066,8 +1066,8 @@ finish_processing_source(datum_t *key, datum_t *val, void *arg)
    metric = (Metric_t*) val->data;
    type = getfield(metric->strings, metric->type);
 
-   /* Don't save to RRD if the datasource is dead */
-   if( xmldata->ds->dead )
+   /* Don't save to RRD if the datasource is dead or write_rrds is off */
+   if( xmldata->ds->dead || gmetad_config.write_rrds != 1)
       return 1;
 
    tt = in_type_list(type, strlen(type));
@@ -1089,9 +1089,9 @@ finish_processing_source(datum_t *key, datum_t *val, void *arg)
 
    /* Save the data to a round robin database if this data source is 
     * alive. */
-   if (!xmldata->ds->dead && !xmldata->rval) 
+   if (!xmldata->ds->dead && !xmldata->rval)
      {
-   
+
        debug_msg("Writing Summary data for source %s, metric %s",
                  xmldata->sourcename, name);
 


### PR DESCRIPTION
This is useful when gmetad is configured to send data to graphite.
Instead of writing out rrds natively and then whisper files later,
just send the data to carbon and let it write out  whisper  files.

**NOTE: I'm still relatively new to doing much with C other than reading it.**

This is a `RFC`, not a _Please merge this I think I am awesome_. I'm curious if this is the right approach to disable writing of rrds by gmetad. In our instance, I'd like to put gmetad and the main carbon instance on the same webserver, but I'd rather have ganglia-web pull the graphs from graphite directly. A double IO hit from carbon/whisper + rrdtool slamming the disk is suboptimal.

Is this approach even close to what you'd consider merge worthy?
