### PR TITLE
gmetad buffer overflow with metric value of DOUBLE_MAX 

### DIFF
--- a/gmetad/process_xml.c
+++ b/gmetad/process_xml.c
@@ -1058,7 +1058,7 @@ finish_processing_source(datum_t *key, datum_t *val, void *arg)
 {
    xmldata_t *xmldata = (xmldata_t *) arg;
    char *name, *type;
-   char sum[256];
+   char sum[512];
    char num[256];
    Metric_t *metric;
    struct type_tag *tt;


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/HADOOP-8052 for a description of the problem - in essence, 256 bytes is not wide enough to store the maximum value that can be stored in a double precision variable.
