### PR TITLE
Don't die when you HUP gmond -p

### DIFF
--- a/lib/update_pidfile.c
+++ b/lib/update_pidfile.c
@@ -31,8 +31,16 @@ update_pidfile (char *pidfile)
       if (fscanf(file, "%ld", &p) == 1 && (pid = p) &&
           (getpgid (pid) > -1))
         {
-          err_msg("daemon already running: %s pid %ld\n", pidfile, p);
-          exit (1);
+	  if (pid != getpid())
+	    {
+              err_msg("daemon already running: %s pid %ld\n", pidfile, p);
+              exit (1);
+	    }
+	  else
+	    {
+	      /* We have the same PID so were probably HUP'd */
+	      return;
+	    }
         }
       fclose (file);
     }


### PR DESCRIPTION
If you HUP gmond and you ran it with -p it will reexec itself, keeping its
pid, read the pidfile, find a process with its pid running and exit (so as
to prevent two gmonds running at once).  This isn't correct as it should
just keep running and not do anything with its pidfile.
