### PR TITLE
become_a_nobody: call setgid and initgroups to update group list.

### DIFF
--- a/lib/become_a_nobody.c
+++ b/lib/become_a_nobody.c
@@ -2,7 +2,11 @@
 #include "config.h"
 #endif
 
-#include <stdio.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <grp.h>
+#include <pwd.h>
+
 #include "become_a_nobody.h"
 #include <gm_msg.h>
 
@@ -11,7 +15,7 @@ become_a_nobody( const char *username )
 {
    int rval;
    struct passwd *pw;
- 
+
    pw = getpwnam(username);
    if ( pw == NULL )
      {
@@ -19,14 +23,27 @@ become_a_nobody( const char *username )
      }
 
    rval = getuid();
-   if ( rval != pw->pw_uid )  
+   if ( rval != pw->pw_uid )
      {
        if ( rval != 0 )
          {
            err_quit("Must be root to setuid to \"%s\"\n\n", username);
          }
 
-       rval = setuid(pw->pw_uid); 
+       rval = setgid(pw->pw_gid);
+       if ( rval < 0 )
+         {
+           err_quit("exiting. setgid %d error", (int) pw->pw_gid);
+         }
+
+       rval = initgroups(username, pw->pw_gid);
+       if ( rval < 0 )
+         {
+           err_quit("exiting. initgroups '%s', %d error",
+             username, (int) pw->pw_gid);
+         }
+
+       rval = setuid(pw->pw_uid);
        if ( rval < 0 )
          {
            err_quit("exiting. setuid '%s' error", username);

--- a/lib/become_a_nobody.h
+++ b/lib/become_a_nobody.h
@@ -1,8 +1,5 @@
 #ifndef BECOME_A_NOBODY_H
 #define BECOME_A_NOBODY_H 1
-#include <pwd.h>
-#include <sys/types.h>
-#include <unistd.h>
 
 void become_a_nobody(const char *username);
 


### PR DESCRIPTION
Without this patch gmond is (usually) run just as a ganglia user in root group and all system services that need to be monitored must be accessible by ganglia:root.  With the patch the ganglia user can be added to groups that provide access to the required resources.  In any case running the gmond process with root's groups is usually not the desired behavior.
