### PR TITLE
Fix gmetad so that grid-of-grids works again

### DIFF
--- a/gmetad/process_xml.c
+++ b/gmetad/process_xml.c
@@ -1174,7 +1174,7 @@ end (void *data, const char *el)
       {
          case GRID_TAG:
             rc = endElement_GRID(data, el);
-	    break;
+	    /* No break. */
 
          case CLUSTER_TAG:
             rc = endElement_CLUSTER(data, el);


### PR DESCRIPTION
The commit ganglia/monitor-core@c927c5d8afcaeac82985f3426f7c311ae41690a7 which was pulled from fastly/ganglia@06899ac3556c608f1ab8607ed8cfab88e8f074e9 may have stopped gmetad from generating lots of rrd errors however it meant that gmetad's could no longer work in 'scalable' mode. ie. grid-of-grids broke.
