### PR TITLE
Add additional thread mutex lock for hostdata hashtable

### DIFF
--- a/gmond/gmond_internal.h
+++ b/gmond/gmond_internal.h
@@ -58,6 +58,8 @@ struct Ganglia_host {
   apr_time_t first_heard_from;
   /* Last heard from */
   apr_time_t last_heard_from;
+  /* Thread mutex */
+  apr_thread_mutex_t *mutex;
 #ifdef SFLOW
   struct _SFlowAgent *sflow;
 #endif


### PR DESCRIPTION
A mutex was required on the hostdata hashtable to prevent a possible
race condition where new metrics are added to the hashtable or old
metrics are expired (via dmax) while the metrics for a host are
being output by the TCP thread.
