### PR TITLE
gmetad: http support for interactive protocol.

### DIFF
--- a/gmetad/gmetad.h
+++ b/gmetad/gmetad.h
@@ -128,8 +128,9 @@ metric_val_t;
 typedef struct
    {
       int fd;
+      unsigned int valid:1;
+      unsigned int http:1;
       struct sockaddr_in addr;
-      int valid;
       filter_type_t filter;
       struct timeval now;
    }


### PR DESCRIPTION
If the interactive query begins with "GET " and ends with " HTTP/1.0"
or " HTTP/1.1" send the response with a HTTP header and do not send a
full XML dump in case there are no matches.  The behavior for existing
interactive protocol does not change.
