### PR TITLE
Correct APR pool used for override hostname

### DIFF
--- a/gmond/gmond.c
+++ b/gmond/gmond.c
@@ -2750,17 +2750,7 @@ Ganglia_collection_group_send( Ganglia_collection_group *group, apr_time_t now)
             name = cb->msg.Ganglia_value_msg_u.gstr.metric_id.name;
             if (override_hostname != NULL)
               {
-#if 0
-                char* tmpstr = malloc( strlen(( override_ip != NULL ? override_ip : override_hostname )) + strlen( override_hostname ) + 1 );
-                strcpy (tmpstr, (char *)( override_ip != NULL ? override_ip : override_hostname ) );
-                strcat (tmpstr, ":");
-                strcat (tmpstr, (char *) override_hostname);
-
-                cb->msg.Ganglia_value_msg_u.gstr.metric_id.host = tmpstr;
-#endif
-#if 1
-                cb->msg.Ganglia_value_msg_u.gstr.metric_id.host = apr_pstrcat(gm_pool, (char *)( override_ip != NULL ? override_ip : override_hostname ), ":", (char *) override_hostname, NULL);
-#endif
+                cb->msg.Ganglia_value_msg_u.gstr.metric_id.host = apr_pstrcat(global_context, (char *)( override_ip != NULL ? override_ip : override_hostname ), ":", (char *) override_hostname, NULL);
                 cb->msg.Ganglia_value_msg_u.gstr.metric_id.spoof = TRUE;
               }
             val = apr_pstrdup(gm_pool, host_metric_value(cb->info, &(cb->msg)));


### PR DESCRIPTION
The global_context pool should be used by the apr_pstrcat() call that generates the override_hostname variable otherwise corruption can occur. Alternative non-APR version of the code has also been removed.
