### PR TITLE
Increase BUFFSIZE

### DIFF
--- a/include/gm_file.h
+++ b/include/gm_file.h
@@ -5,7 +5,7 @@
 
 /* Never changes */
 #ifndef BUFFSIZE
-#define BUFFSIZE 4096
+#define BUFFSIZE 65536
 #endif
 
 typedef struct {


### PR DESCRIPTION
Please increase BUFFSIZE. It is too small, and spams our logs with "slurpfile() read() buffer
overflow on file /proc/stat".

/proc/stat sizes in our main appserver cluster: http://paste.tstarling.com/p/vXIIUp.html
