### PR TITLE
gmetad: Add wildcard support to gmetad http query interface.

### DIFF
--- a/gmetad/server_priv.h
+++ b/gmetad/server_priv.h
@@ -1,0 +1,12 @@
+#ifndef SERVER_PRIV_H
+#define SERVER_PRIV_H 1
+
+struct request_context {
+  char *path;
+  client_t *client;
+};
+
+static int
+process_path_adapter (datum_t *key, datum_t *val, void *arg);
+
+#endif


### PR DESCRIPTION
The word "any" is treated as a wildcard. A query for "/any/any/metric_name" would include all metrics named "metric_name" from all hosts. This change does not affect the non-http query interface.
