### PR TITLE
Bug in rrd_helpers.c related to carbon_timeout configuration

### DIFF
--- a/gmetad/rrd_helpers.c
+++ b/gmetad/rrd_helpers.c
@@ -243,11 +243,16 @@ push_data_to_carbon( char *graphite_msg)
   int port;
   int carbon_socket;
   struct sockaddr_in server;
-  int carbon_timeout = 500;
+  int carbon_timeout ;
   int nbytes;
   struct pollfd carbon_struct_poll;
   int poll_rval;
   int fl;
+
+  if (gmetad_config.carbon_timeout)
+      carbon_timeout=gmetad_config.carbon_timeout;
+  else
+      carbon_timeout = 500;
 
   if (gmetad_config.carbon_port)
      port=gmetad_config.carbon_port;


### PR DESCRIPTION
While trying to modify carbon_timeout using gmetad.conf
noticed timeout wasn't affecting actual socket timeout.
this was due to a bug in rrd_helpers.c while checking the
configuration value of the carbon_timeout variable in
gmetad.conf
and relying on the default 500 ms value.

Credit for the discovery of the bug goes to Leonid
Mirsky leonidlm@gmail.com
