### PR TITLE
Add support for multiple metric groups to gmetric

### DIFF
--- a/gmetric/cmdline.c.in
+++ b/gmetric/cmdline.c.in
@@ -42,7 +42,7 @@ const char *gengetopt_args_info_help[] = {
   "  -s, --slope=STRING    Either zero|positive|negative|both  (default=`both')",
   "  -x, --tmax=INT        The maximum time in seconds between gmetric calls  \n                          (default=`60')",
   "  -d, --dmax=INT        The lifetime in seconds of this metric  (default=`0')",
-  "  -g, --group=STRING    Group of the metric",
+  "  -g, --group=STRING    Group(s) of the metric (comma-separated)",
   "  -C, --cluster=STRING  Cluster of the metric",
   "  -D, --desc=STRING     Description of the metric",
   "  -T, --title=STRING    Title of the metric",

--- a/gmetric/gmetric.c
+++ b/gmetric/gmetric.c
@@ -111,7 +111,12 @@ main( int argc, char *argv[] )
   if(args_info.cluster_given)
       Ganglia_metadata_add(gmetric, "CLUSTER", args_info.cluster_arg);
   if(args_info.group_given)
-      Ganglia_metadata_add(gmetric, "GROUP", args_info.group_arg);
+    {
+      char *last;
+      for (char *group = apr_strtok(args_info.group_arg, ", ", &last); group != NULL; group = apr_strtok(NULL, ", ", &last)) {
+        Ganglia_metadata_add(gmetric, "GROUP", group);
+      }
+    }
   if(args_info.desc_given)
       Ganglia_metadata_add(gmetric, "DESC", args_info.desc_arg);
   if(args_info.title_given)


### PR DESCRIPTION
This brings gmetric into line with Ganglia python modules which
already support comma-separated groups in metric descriptors.
