### PR TITLE
Stop gmetad segfaulting on empty cluster or grid tags

### DIFF
--- a/gmetad/gmetad.c
+++ b/gmetad/gmetad.c
@@ -254,6 +254,8 @@ write_root_summary(datum_t *key, datum_t *val, void *arg)
 	 if (gmetad_config.write_rrds == 0)
 	     return 0;
 
+   debug_msg("Writing Root Summary data for metric %s", name);
+
    rc = write_data_to_rrd( NULL, NULL, name, sum, num, 15, 0, metric->slope);
    if (rc)
       {


### PR DESCRIPTION
When run in non-scalable mode, gmetad segfaults if the downstream gmetad returns an empty GRID (which can happen if no gmonds for a data source are responding). The segfaults are caused by attempts to unlock a GRID and CLUSTER mutex that isn't set because gmetad's in non-scalable mode ignore GRID tags and so the mutex was never set in the first place.

To prevent unlocking mutexes that haven't been set it was necessary to change the switch statement that is used to write RRD summaries on all &lt;/GRID&gt; and &lt;/CLUSTER&gt; end tags. One unintended benefit of this patch is that a major cause of the RRD_update error messages "illegal attempt to update using time 1358335262 when last update time is 1358335262 (minimum one second step)" no longer occurs. (Note that there are still other reasons that this error might be generated such as multiple clusters with the same name or servers not being time synched).
