### PR TITLE
Update gmond/modules/python/mod_python.c

### DIFF
--- a/gmond/modules/python/mod_python.c
+++ b/gmond/modules/python/mod_python.c
@@ -74,7 +74,7 @@ mapped_info_t;
 
 typedef struct
 {
-    char mname[128];
+    char mname[251];  // 255 (a fairly common filename max) - 4 (".rrd")
     int tmax;
     char vtype[32];
     char units[64];


### PR DESCRIPTION
Upped metric name limits to the maximum that common FS's (such as extFS) wil allow.
