### PR TITLE
Use strtoull when available to parse network metrics on Linux

### DIFF
--- a/libmetrics/configure.ac
+++ b/libmetrics/configure.ac
@@ -72,7 +72,7 @@ AC_FUNC_MALLOC
 AC_FUNC_REALLOC
 AC_FUNC_STAT
 AC_FUNC_STRTOD
-AC_CHECK_FUNCS([getmntinfo getpagesize gettimeofday memset pstat_getdynamic strchr strdup strndup strpbrk strstr strtol sysinfo uname vsnprintf strlcat])
+AC_CHECK_FUNCS([getmntinfo getpagesize gettimeofday memset pstat_getdynamic strchr strdup strndup strpbrk strstr strtol strtoull sysinfo uname vsnprintf strlcat])
 
 if test x"$ac_cv_c_compiler_gnu" = xyes; then
    CFLAGS="$CFLAGS -Wall"


### PR DESCRIPTION
Not sure if Bugzilla is still used, but I filed a bug over there: http://bugzilla.ganglia.info/cgi-bin/bugzilla/show_bug.cgi?id=342

> In monitor-core/libmetrics/linux/metrics.c, strtoul is used to parse the network packet and byte counts from /proc/net/dev. On modern 32-bit systems (e.g. ARMv7), these counts are often 64-bit, whereas unsigned long is 32 bits. When the counts exceed ULONG_MAX, Ganglia incorrectly reports 0 network bytes in/out from then on.

This commit uses strtoull when it is available for parsing network stats.
