### PR TITLE
Slab reclaimable support in Linux

### DIFF
--- a/gmond/modules/memory/mod_mem.c
+++ b/gmond/modules/memory/mod_mem.c
@@ -47,6 +47,10 @@ static g_val_t mem_metric_handler ( int metric_index )
         return swap_free_func();
     case 6:
         return swap_total_func();
+#ifdef LINUX
+    case 7:
+        return mem_sreclaimable_func();
+#endif
 #if HPUX
     case 7:
         return mem_arm_func();
@@ -73,6 +77,9 @@ static Ganglia_25metric mem_metric_info[] =
     {0, "mem_cached",  180, GANGLIA_VALUE_FLOAT, "KB", "both", "%.0f", UDP_HEADER_SIZE+8, "Amount of cached memory"},
     {0, "swap_free",   180, GANGLIA_VALUE_FLOAT, "KB", "both", "%.0f", UDP_HEADER_SIZE+8, "Amount of available swap memory"},
     {0, "swap_total", 1200, GANGLIA_VALUE_FLOAT, "KB", "zero", "%.0f", UDP_HEADER_SIZE+8, "Total amount of swap space displayed in KBs"},
+#ifdef LINUX
+    {0, "mem_sreclaimable", 180, GANGLIA_VALUE_FLOAT, "KB", "both", "%.0f", UDP_HEADER_SIZE+8, "Amount of reclaimable slab memory"},
+#endif
 #if HPUX
     {0, "mem_arm",     180, GANGLIA_VALUE_FLOAT, "KB", "both", "%.0f", UDP_HEADER_SIZE+8, "mem_arm"},
     {0, "mem_rm",      180, GANGLIA_VALUE_FLOAT, "KB", "both", "%.0f", UDP_HEADER_SIZE+8, "mem_rm"},

--- a/libmetrics/libmetrics.h
+++ b/libmetrics/libmetrics.h
@@ -76,6 +76,10 @@ void libmetrics_init( void );
  g_val_t heartbeat_func(void);
  g_val_t location_func(void);
 
+#ifdef LINUX
+ g_val_t mem_sreclaimable_func (void);
+#endif
+
 /* the following are additional internal metrics added by swagner
  * what for the monitoring of buffer/linear read/writes on Solaris boxen.
  * these are only valid on the solaris version of gmond v2.3.1b1,

--- a/libmetrics/linux/metrics.c
+++ b/libmetrics/linux/metrics.c
@@ -1190,6 +1190,23 @@ mem_buffers_func ( void )
 }
 
 g_val_t
+mem_sreclaimable_func ( void )
+{
+   char *p;
+   g_val_t val;
+
+   p = strstr( update_file(&proc_meminfo), "SReclaimable:" );
+   if(p) {
+     p = skip_token(p);
+     val.f = atof( p );
+   } else {
+     val.f = 0;
+   }
+
+   return val;
+}
+
+g_val_t
 mem_cached_func ( void )
 {
    char *p;


### PR DESCRIPTION
Hello,

On servers that deal with lots of files, the Linux dentry cache takes up a large portion of the total memory. This is reflected in the SReclaimable in /proc/meminfo

MemFree in /proc/meminfo does not subtract this amount, even though 'technically' it is free (where free is defined as usable by user-processes). 

Better visibility into this memory use should reduce freakouts. The attached patch adds this to the core memory module.
