### PR TITLE
Fixed a logic error with my recent gzip patch

### DIFF
--- a/gmond/gmond.c
+++ b/gmond/gmond.c
@@ -264,7 +264,7 @@ socket_send(apr_socket_t *sock, const char *buf, apr_size_t *len)
   int z_ret;
 
   ret = apr_socket_data_get((void**)&strm, GZIP_KEY, sock);
-  if (ret != APR_SUCCESS)
+  if (ret != APR_SUCCESS || strm == NULL)
     {
       ret = socket_send_raw( sock, buf, len );
     }


### PR DESCRIPTION
The gzip patch I submitted recently assumes that apr_socket_data_get returns with an error code if there is no data in the socket; however, this is not always the case. This patch explicitly checks for the data we want instead of relying on the error code to indicate its presence.
