### PR TITLE
Improve metric summarization performance under heavy load

### DIFF
--- a/gmetad/cleanup.c
+++ b/gmetad/cleanup.c
@@ -129,6 +129,7 @@ cleanup_source ( datum_t *key, datum_t *val, void *arg )
 #if 0
    unsigned int born;
 #endif
+   hash_t *metric_summary;
 
    /* Currently we never delete a source. */
    
@@ -136,12 +137,13 @@ cleanup_source ( datum_t *key, datum_t *val, void *arg )
    cleanup.tv = tv;
    cleanup.key = 0;
    cleanup.hashval = 0;
-   while (hash_walkfrom(source->metric_summary, cleanup.hashval, 
+   metric_summary = source->metric_summary; /* Just look at the current one */
+   while (hash_walkfrom(metric_summary, cleanup.hashval, 
                            cleanup_metric, (void*) &cleanup)) {
 
       if (cleanup.key) {
-         cleanup.hashval = hashval(cleanup.key, source->metric_summary);
-         rv=hash_delete(cleanup.key, source->metric_summary);
+         cleanup.hashval = hashval(cleanup.key, metric_summary);
+         rv=hash_delete(cleanup.key, metric_summary);
          if (rv) datum_free(rv);
          cleanup.key=0;
       }

--- a/gmetad/gmetad.h
+++ b/gmetad/gmetad.h
@@ -168,6 +168,7 @@ typedef struct
       hash_t *authority; /* Null for a grid. */
       short int authority_ptr; /* An authority URL. */
       hash_t *metric_summary;
+      hash_t *metric_summary_pending;
       pthread_mutex_t *sum_finished; /* A lock held during summarization. */
       data_source_list_t *ds;
       uint32_t hosts_up;


### PR DESCRIPTION
When computing summary metrics, gmetad's current behavior is for
each cluster thread to grab the summarization lock, peform all of
its summarization, and then release the lock. This can block the
global aggregation thread if a single cluster is taking a long
time to summarize its RRDs for whatever reason; this issue
manifests are dropouts in the cluster and grid summary RRDs. This
also comes up if you have a large number of large clusters which
each take a long time to summarize.

The change here is to have each cluster thread perform its
summarization into a "pending" hash table independently, and then
once the summarization is complete each thread 1) grabs the lock,
2) swaps in the finished pending hash table with the fully-
aggregated one, and then 3) releases the lock immediately.
This significantly reduces the amount of time that the
summarization lock is held by each cluster thread, and also
eliminates the possibility of a single blocked cluster thread
preventing all summary metrics from being written.
