### PR TITLE
Forward metrics to Graphite using UDP carbon protocol

### DIFF
--- a/gmetad/conf.c.in
+++ b/gmetad/conf.c.in
@@ -270,6 +270,14 @@ static DOTCONF_CB(cb_carbon_port)
    return NULL;
 }
 
+static DOTCONF_CB(cb_carbon_protocol)
+{
+   gmetad_config_t *c = (gmetad_config_t*) cmd->option->info;
+   debug_msg("Setting carbon protocol to %s", cmd->data.str);
+   c->carbon_protocol = strdup (cmd->data.str);
+   return NULL;
+}
+
 static DOTCONF_CB(cb_carbon_timeout)
 {
    gmetad_config_t *c = (gmetad_config_t*) cmd->option->info;
@@ -345,6 +353,7 @@ static configoption_t gmetad_options[] =
       {"case_sensitive_hostnames", ARG_INT, cb_case_sensitive_hostnames, &gmetad_config, 0},
       {"carbon_server", ARG_STR, cb_carbon_server, &gmetad_config, 0},
       {"carbon_port", ARG_INT, cb_carbon_port, &gmetad_config, 0},
+      {"carbon_protocol", ARG_STR, cb_carbon_protocol, &gmetad_config, 0},
       {"carbon_timeout", ARG_INT, cb_carbon_timeout, &gmetad_config, 0},
       {"memcached_parameters", ARG_STR, cb_memcached_parameters, &gmetad_config, 0},
       {"graphite_prefix", ARG_STR, cb_graphite_prefix, &gmetad_config, 0},
@@ -375,6 +384,9 @@ set_defaults (gmetad_config_t *config)
    config->RRAs[1] = "RRA:AVERAGE:0.5:4:20160";
    config->RRAs[2] = "RRA:AVERAGE:0.5:40:52704";
    config->case_sensitive_hostnames = 1;
+   config->carbon_port = 2003;
+   config->carbon_protocol = "tcp";
+   config->carbon_timeout = 500;
    config->unsummarized_metrics = NULL;
 }
 

--- a/gmetad/conf.h
+++ b/gmetad/conf.h
@@ -20,6 +20,7 @@ typedef struct
       char *rrd_rootdir;
       char *carbon_server;
       int carbon_port;
+      char *carbon_protocol;
       int carbon_timeout;
       char *memcached_parameters;
       char *graphite_prefix;

--- a/gmetad/export_helpers.h
+++ b/gmetad/export_helpers.h
@@ -19,6 +19,8 @@ write_data_to_memcached ( const char *cluster, const char *host, const char *met
                     const char *sum, unsigned int process_time, unsigned int expiry );
 #endif /* WITH_MEMCACHED */
 
+g_udp_socket*
+init_carbon_udp_socket (const char *hostname, uint16_t port);
 int
 write_data_to_carbon ( const char *source, const char *host, const char *metric, 
                     const char *sum, unsigned int process_time);

--- a/gmetad/gmetad.conf.in
+++ b/gmetad/gmetad.conf.in
@@ -150,9 +150,12 @@ case_sensitive_hostnames 0
 # default: unspecified
 # carbon_server "my.graphite.box"
 #
-# The port on which Graphite is listening
+# The port and protocol on which Graphite is listening
 # default: 2003
 # carbon_port 2003
+#
+# default: tcp
+# carbon_protocol udp
 #
 # **Deprecated in favor of graphite_path** A prefix to prepend to the 
 # metric names exported by gmetad. Graphite uses dot-

--- a/lib/net.h
+++ b/lib/net.h
@@ -42,6 +42,7 @@ typedef struct
 
 /* No difference between mcast and tcp sockets for now */
 typedef g_mcast_socket g_tcp_socket;
+typedef g_mcast_socket g_udp_socket;
 
 /************** INETADDR  ****************/
 


### PR DESCRIPTION
This approach uses a single UDP socket for forwarding all metrics to Graphite instead of opening and closing a TCP connection for every sent metric.

Note: The UDP listener for carbon is off by default. To turn it on modify carbon.conf like so:

```
[cache]
ENABLE_UDP_LISTENER = True
```
