### PR TITLE
Treat mc_bytes as a gauge (part 2)

### DIFF
--- a/gmond/sflow.c
+++ b/gmond/sflow.c
@@ -863,7 +863,6 @@ process_struct_MEMCACHE(SFlowXDR *x, SFlowDataSource *dataSource, Ganglia_host *
     submit_sflow_float(hostdata, metric_prefix, SFLOW_M_mc_total_items, SFLOW_CTR_RATE(dataSource, mc_total_items, ctr_ival_mS), SFLOW_OK_COUNTER32(mc_total_items));
     submit_sflow_float(hostdata, metric_prefix, SFLOW_M_mc_bytes_read, SFLOW_CTR_RATE(dataSource, mc_bytes_read, ctr_ival_mS), SFLOW_OK_COUNTER64(mc_bytes_read));
     submit_sflow_float(hostdata, metric_prefix, SFLOW_M_mc_bytes_written, SFLOW_CTR_RATE(dataSource, mc_bytes_written, ctr_ival_mS), SFLOW_OK_COUNTER64(mc_bytes_written));
-    submit_sflow_float(hostdata, metric_prefix, SFLOW_M_mc_bytes, SFLOW_CTR_RATE(dataSource, mc_bytes, ctr_ival_mS), SFLOW_OK_COUNTER64(mc_bytes));
   }
 
 
@@ -891,7 +890,6 @@ process_struct_MEMCACHE(SFlowXDR *x, SFlowDataSource *dataSource, Ganglia_host *
   SFLOW_CTR_LATCH(dataSource, mc_total_items);
   SFLOW_CTR_LATCH(dataSource, mc_bytes_read);
   SFLOW_CTR_LATCH(dataSource, mc_bytes_written);
-  SFLOW_CTR_LATCH(dataSource, mc_bytes);
 
   /* and the GAUGES too */
   submit_sflow_uint32(hostdata, metric_prefix, SFLOW_M_mc_threads, mc_threads, SFLOW_OK_GAUGE32(mc_threads));
@@ -901,6 +899,7 @@ process_struct_MEMCACHE(SFlowXDR *x, SFlowDataSource *dataSource, Ganglia_host *
   submit_sflow_uint32(hostdata, metric_prefix, SFLOW_M_mc_conn_structs, mc_conn_structs, SFLOW_OK_GAUGE32(mc_conn_structs));
   /* there does not seem to be a way to submit a 64-bit integer value, so cast this one to double */
   submit_sflow_double(hostdata, metric_prefix, SFLOW_M_mc_limit_maxbytes, (double)mc_limit_maxbytes, SFLOW_OK_GAUGE64(mc_limit_maxbytes));
+  submit_sflow_double(hostdata, metric_prefix, SFLOW_M_mc_bytes, (double)mc_bytes, SFLOW_OK_GAUGE64(mc_bytes));
 }
 
 static void


### PR DESCRIPTION
There was a second place to make this change.
