### PR TITLE
send the basic system metrics in a timely fashion

### DIFF
--- a/debian/gmond.conf
+++ b/debian/gmond.conf
@@ -107,11 +107,10 @@ collection_group {
   } 
 } 
 
-/* This collection group will send general info about this host every 1200 secs. 
-   This information doesn't change between reboots and is only collected once. */ 
+/* This collection group will send general info about this host. */
 collection_group { 
-  collect_once = yes 
-  time_threshold = 1200 
+  collect_every = 60
+  time_threshold = 60
   metric { 
     name = "cpu_num" 
     title = "CPU Count" 
@@ -124,7 +123,6 @@ collection_group {
     name = "mem_total" 
     title = "Memory Total" 
   } 
-  /* Should this be here? Swap can be added/removed between reboots. */ 
   metric { 
     name = "swap_total" 
     title = "Swap Space Total" 

--- a/lib/default_conf.h.in
+++ b/lib/default_conf.h.in
@@ -160,13 +160,10 @@ collection_group {\n\
   }\n\
 }\n\
 \n\
-/* This collection group will send general info about this host every\n\
-   1200 secs.\n\
-   This information doesn't change between reboots and is only collected\n\
-   once. */\n\
+/* This collection group will send general info about this host*/\n\
 collection_group {\n\
-  collect_once = yes\n\
-  time_threshold = 1200\n\
+  collect_every = 60\n\
+  time_threshold = 60\n\
   metric {\n\
     name = \"cpu_num\"\n\
     title = \"CPU Count\"\n\
@@ -179,7 +176,6 @@ collection_group {\n\
     name = \"mem_total\"\n\
     title = \"Memory Total\"\n\
   }\n\
-  /* Should this be here? Swap can be added/removed between reboots. */\n\
   metric {\n\
     name = \"swap_total\"\n\
     title = \"Swap Space Total\"\n\


### PR DESCRIPTION
This should avoid the "negative total memory" problem people see in
their reports after restarting daemons.

A (minor) optimization would be to break apart the things that really really don't change are only collected once, but I'd rather err on the side of easy to use defaults

```
<vvuksan> if someone wants to fix that in the template
<vvuksan> and submit a pull request
<vvuksan> that would be awesome
```
