### PR TITLE
Add option to prevent gmetad from generating summaries for sFlow VM metrics

### DIFF
--- a/gmetad/conf.c.in
+++ b/gmetad/conf.c.in
@@ -326,6 +326,14 @@ static DOTCONF_CB(cb_unsummarized_metrics)
    return NULL;
 }
 
+static DOTCONF_CB(cb_unsummarized_sflow_vm_metrics)
+{
+   gmetad_config_t *c = (gmetad_config_t*) cmd->option->info;
+   debug_msg("Setting unsummarized_sflow_vm_metrics = %ld", cmd->data.value);
+   c->unsummarized_sflow_vm_metrics = cmd->data.value;
+   return NULL;
+}
+
 static FUNC_ERRORHANDLER(errorhandler)
 {
    err_quit("gmetad config file error: %s\n", msg);
@@ -359,6 +367,7 @@ static configoption_t gmetad_options[] =
       {"graphite_prefix", ARG_STR, cb_graphite_prefix, &gmetad_config, 0},
       {"graphite_path", ARG_STR, cb_graphite_path, &gmetad_config, 0},
       {"unsummarized_metrics", ARG_LIST, cb_unsummarized_metrics, &gmetad_config, 0},
+      {"unsummarized_sflow_vm_metrics", ARG_TOGGLE, cb_unsummarized_sflow_vm_metrics, &gmetad_config, 0},
       LAST_OPTION
    };
 
@@ -388,6 +397,7 @@ set_defaults (gmetad_config_t *config)
    config->carbon_protocol = "tcp";
    config->carbon_timeout = 500;
    config->unsummarized_metrics = NULL;
+   config->unsummarized_sflow_vm_metrics = 0;
 }
 
 int

--- a/gmetad/conf.h
+++ b/gmetad/conf.h
@@ -13,6 +13,7 @@ typedef struct
       int server_threads;
       int umask;
       llist_entry *trusted_hosts;
+      int unsummarized_sflow_vm_metrics;
       llist_entry *unsummarized_metrics;
       int debug_level;
       int should_setuid;

--- a/gmetad/gmetad.c
+++ b/gmetad/gmetad.c
@@ -230,6 +230,7 @@ write_root_summary(datum_t *key, datum_t *val, void *arg)
    int rc;
    struct type_tag *tt;
    llist_entry *le;
+   char *p;
 
    name = (char*) key->data;
    metric = (Metric_t*) val->data;
@@ -244,6 +245,10 @@ write_root_summary(datum_t *key, datum_t *val, void *arg)
    /* Don't write a summary for metrics not to be summarized */
    if (llist_search(&(gmetad_config.unsummarized_metrics), (void *)key->data, llist_strncmp, &le) == 0)
        return 0;
+
+   /* Don't write a summary for metris that appears to be sFlow VM metrics */
+   if (gmetad_config.unsummarized_sflow_vm_metrics && (p = strchr(name, '.')) != NULL && *(p+1) == 'v')
+     return 0;
 
    /* We log all our sums in double which does not suffer from
       wraparound errors: for example memory KB exceeding 4TB. -twitham */

--- a/gmetad/gmetad.conf.in
+++ b/gmetad/gmetad.conf.in
@@ -133,6 +133,11 @@ data_source "my cluster" localhost
 # unsummarized_metrics diskstat CPU
 #
 #-------------------------------------------------------------------------------
+# Prevent gmetad from generating summaries for sFlow VM metrics
+# default: off
+# unsummarized_sflow_vm_metrics on
+#
+#-------------------------------------------------------------------------------
 # In earlier versions of gmetad, hostnames were handled in a case
 # sensitive manner
 # If your hostname directories have been renamed to lower case,

--- a/gmetad/process_xml.c
+++ b/gmetad/process_xml.c
@@ -1072,6 +1072,7 @@ finish_processing_source(datum_t *key, datum_t *val, void *arg)
    Metric_t *metric;
    struct type_tag *tt;
    llist_entry *le;
+   char *p;
 
    name = (char*) key->data;
    metric = (Metric_t*) val->data;
@@ -1087,6 +1088,10 @@ finish_processing_source(datum_t *key, datum_t *val, void *arg)
    /* Don't save to RRD if this is a metric not to be summarized */
    if (llist_search(&(gmetad_config.unsummarized_metrics), (void *)name, llist_strncmp, &le) == 0)
       return 0;
+
+   /* Don't save to RRD if this metrics appears to be an sFlow VM metrics */
+   if (gmetad_config.unsummarized_sflow_vm_metrics && (p = strchr(name, '.')) != NULL && *(p+1) == 'v')
+       return 0;
 
    switch (tt->type)
       {


### PR DESCRIPTION
This patch adds a new "unsummarized_sflow_vm_metrics" config option to gmetad
to prevent generating summaries for metrics that appears to be sFlow VM metrics.

It doesn't really make sense to generate summaries for VM metrics, since the VM metrics are prefixed by the VM name / ID, ex. vm1.vdisk_capacity, vm2.vdisk_capacity, vm3.vdisk_capacity, etc.

A metric is determined to be an sFlow VM metric when the metric name contains
character '.' followed by character 'v'.

Ex: xenvm1.vcpu_num is an sFlow VM metric, vnode_cpu_num is not.

I'm not entirely satisfied with how the metrics are determined to be sFlow VM metric. I've though of looking at the metric TITLE and DESC extended attribute but haven't found a way to get that information (matching that the VM name ex. xenvm1 in the previous example match the beginning of TITLE or DESC). There is a risk of metrics being inappropriately flagged as sFlow VM metrics (ex. a metric that would be named apache.visitors would match).

Comments and feedbacks are more than welcome.

Simon
