### PR TITLE
Errors in the python netstats module

### DIFF
--- a/gmond/python_modules/network/netstats.py
+++ b/gmond/python_modules/network/netstats.py
@@ -109,6 +109,8 @@ def get_tcploss_percentage(name):
 	pct = 0
     except KeyError:
       pct = 0.0
+    except ZeroDivisionError:
+      pct = 0.0
 
     return pct
 
@@ -123,6 +125,8 @@ def get_retrans_percentage(name):
 	print name + " is less 0"
 	pct = 0
     except KeyError:
+      pct = 0.0
+    except ZeroDivisionError:
       pct = 0.0
 
     return pct


### PR DESCRIPTION
I had a lot of the following errors in the syslog of idle nodes :

```
[PYTHON] Can't call the metric handler function for [tcp_retrans_percentage] in the python module [netstats].#012
[PYTHON] Can't call the metric handler function for [tcpext_tcploss_percentage] in the python module [netstats].#012
```

I tracked down the error being a python ZeroDivisionError exception when the values of 'insegs' and 'outsegs' didn't change in the default 15 seconds interval between metric collection.
