### PR TITLE
Add a "summarized_metrics" option.

### DIFF
--- a/gmetad/conf.c.in
+++ b/gmetad/conf.c.in
@@ -366,6 +366,22 @@ static DOTCONF_CB(cb_unsummarized_sflow_vm_metrics)
    return NULL;
 }
 
+static DOTCONF_CB(cb_summarized_metrics)
+{
+   int i;
+   llist_entry *le;
+   gmetad_config_t *c = cmd->option->info;
+
+   for (i = 0; i < cmd->arg_count; i++)
+      {
+         le = malloc(sizeof(*le));
+         le->val = strdup(cmd->data.list[i]);
+         llist_add(&(c->summarized_metrics), le);
+         debug_msg("Adding %s to summarized_metrics", (const char *)le->val);
+      }
+   return NULL;
+}
+
 static FUNC_ERRORHANDLER(errorhandler)
 {
    err_quit("gmetad config file error: %s\n", msg);
@@ -404,6 +420,7 @@ static configoption_t gmetad_options[] =
       {"riemann_attributes", ARG_STR, cb_riemann_attributes, &gmetad_config, 0},
       {"unsummarized_metrics", ARG_LIST, cb_unsummarized_metrics, &gmetad_config, 0},
       {"unsummarized_sflow_vm_metrics", ARG_TOGGLE, cb_unsummarized_sflow_vm_metrics, &gmetad_config, 0},
+      {"summarized_metrics", ARG_LIST, cb_summarized_metrics, &gmetad_config, 0},
       LAST_OPTION
    };
 
@@ -437,6 +454,7 @@ set_defaults (gmetad_config_t *config)
    config->riemann_attributes = NULL;
    config->unsummarized_metrics = NULL;
    config->unsummarized_sflow_vm_metrics = 0;
+   config->summarized_metrics = NULL;
 }
 
 int

--- a/gmetad/conf.h
+++ b/gmetad/conf.h
@@ -15,6 +15,7 @@ typedef struct
       llist_entry *trusted_hosts;
       int unsummarized_sflow_vm_metrics;
       llist_entry *unsummarized_metrics;
+      llist_entry *summarized_metrics;
       int debug_level;
       int should_setuid;
       char *setuid_username;


### PR DESCRIPTION
This feature works notionally the same as unsummarized_metrics, except
it serves as a list of metrics to summarize explicitly (instead of
ignoring metrics to leave out). This can be useful when aggregating
large numbers of metrics where only a very small number of metrics are
actually useful when summarized.

Note that while unsummarized_metrics works for filtering cluster / host
/ metrics, summarized_metrics only changes the behavior of summaries.
