### PR TITLE
Fix configure and makefiles so build process is more robust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ before_script:
   - echo 'yes' | sudo add-apt-repository ppa:ondrej/php5
   - sudo apt-get update
   - sudo apt-get -o Dpkg::Options::="--force-overwrite" -y install libapr1-dev libaprutil1-dev libconfuse-dev libexpat1-dev libpcre3-dev libssl-dev librrd-dev libperl-dev libmemcached-dev libtool m4 gperf zlib1g-dev pkg-config
-  - wget -c http://concurrencykit.org.nyud.net/releases/ck-0.3.5.tar.gz; tar zxvf ck-0.3.5.tar.gz ; (cd ck-0.3.5/ ; ./configure --prefix=/usr && make all && sudo make install )
+  - wget -c http://concurrencykit.org.nyud.net/releases/ck-0.3.5.tar.gz; tar zxvf ck-0.3.5.tar.gz ; (cd ck-0.3.5/ ; ./configure && make all && sudo make install )
 

--- a/configure.ac
+++ b/configure.ac
@@ -524,17 +524,12 @@ AC_ARG_WITH( riemann,
 if test x"$withval" = xyes; then riemann="yes"; fi)
 
 if test x"$riemann" == xyes; then
+  PKG_CHECK_MODULES([PROTOBUF], [libprotobuf-c])
   AC_CHECK_PROGS([PROTOC_C], [protoc-c], [:])
   if test "$PROTOC_C" = :; then
     AC_MSG_ERROR([This package needs 'protoc-c' tool. Try installing the 'protobuf-c-compiler' package.])
   fi
   AC_CONFIG_COMMANDS([riemann_pb-c.c], [protoc-c -Igmetad/ --c_out=./gmetad gmetad/riemann.proto])
-  AC_CHECK_LIB([protobuf-c], [protobuf_c_message_pack])
-  if test x"$ac_cv_lib_protobuf_c_protobuf_c_message_pack" = xno; then
-    echo "libprotobuf-c not found"  # package: libprotobuf-c0-dev
-    exit 1
-  fi
-  LDFLAGS="$LDFLAGS -lprotobuf-c"
   CFLAGS="$CFLAGS -DWITH_RIEMANN"
 fi
 AM_CONDITIONAL(BUILD_RIEMANN, test x"$riemann" = xyes)
@@ -687,9 +682,7 @@ AC_CHECK_HEADER([rpc/xdr.h], [],
 #endif
 ])
 
-AC_CHECK_HEADER([ck_pr.h], [],
-   [AC_MSG_ERROR([your system is missing the concurrency kit headers (http://www.concurrencykit.org)])],
-[])
+PKG_CHECK_MODULES([CK], [ck])
 
 dnl ##################################################################
 dnl Checks for typedefs.

--- a/gmetad/Makefile.am
+++ b/gmetad/Makefile.am
@@ -12,7 +12,7 @@ GLDFLAGS =
 endif
 
 INCLUDES = @APR_INCLUDES@
-AM_CFLAGS = -I$(top_builddir)/lib -I$(top_builddir)/gmond -I$(top_builddir)/include $(GCFLAGS)
+AM_CFLAGS = -I$(top_builddir)/lib -I$(top_builddir)/gmond -I$(top_builddir)/include $(GCFLAGS) @CK_CFLAGS@ @PROTOBUF_CFLAGS@
 
 sbin_PROGRAMS = gmetad
 
@@ -28,7 +28,7 @@ if BUILD_RIEMANN
 endif
 
 gmetad_LDADD   = $(top_builddir)/lib/libganglia.la -lrrd -lm \
-                 $(GLDADD) $(DEPS_LIBS)
+                 $(GLDADD) $(DEPS_LIBS) @CK_LIBS@ @PROTOBUF_LIBS@
 
 gmetad_LDFLAGS = $(GLDFLAGS)
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -15,7 +15,7 @@ GCFLAGS += -DSFLOW
 endif
 
 INCLUDES = @APR_INCLUDES@
-AM_CFLAGS = -I.. -I. -I$(top_builddir)/include/ $(GCFLAGS) -DSYSCONFDIR='"$(sysconfdir)"'
+AM_CFLAGS = -I.. -I. -I$(top_builddir)/include/ $(GCFLAGS) -DSYSCONFDIR='"$(sysconfdir)"' @CK_CFLAGS@
 
 include_HEADERS = gm_protocol.h
 
@@ -37,7 +37,7 @@ libganglia_la_LDFLAGS = \
 	-export-dynamic 
 	$(GLDFLAGS)
 
-libganglia_la_LIBADD = $(GLDADD)	
+libganglia_la_LIBADD = $(GLDADD) @CK_LIBS@
 
 noinst_LIBRARIES = libgetopthelper.a
 # A little helper for getopt functions


### PR DESCRIPTION
Concurrency kit is installed by default into /usr/include/ck
so pkg-config is used to find the headers and libs instead
of overriding the CK location using --prefix=/usr.

When Riemann was enabled during the build process Google
Protocol Buffers was being incorrectly linked to the ganglia agent
eventhough it isn't used. This should now be fixed.
