### PR TITLE
add internal metric counters to gmetad server on port 8652 /status

### DIFF
--- a/gmetad/Makefile.am
+++ b/gmetad/Makefile.am
@@ -22,7 +22,7 @@ cmdline.c: cmdline.c.in $(FIXCONFIG)
 gmetad_SOURCES =  gmetad.c cmdline.c.in cmdline.c cmdline.h gmetad.h data_thread.c \
    server.c process_xml.c rrd_helpers.c export_helpers.c conf.c conf.h type_hash.c \
    xml_hash.c cleanup.c rrd_helpers.h export_helpers.h daemon_init.c daemon_init.h \
-	 server_priv.h  
+	 server_priv.h gm_scoreboard.h
 if BUILD_RIEMANN
   gmetad_SOURCES += riemann.pb-c.h riemann.pb-c.c
 endif

--- a/gmetad/export_helpers.c
+++ b/gmetad/export_helpers.c
@@ -27,6 +27,7 @@
 #endif /* WITH_RIEMANN */
 
 #include "export_helpers.h"
+#include "gm_scoreboard.h"
 
 #define PATHSIZE 4096
 extern gmetad_config_t gmetad_config;
@@ -190,6 +191,8 @@ push_data_to_carbon( char *graphite_msg)
         }
       }
       close (carbon_socket);
+      ganglia_scoreboard_inc(METS_SENT_GRAPHITE);
+      ganglia_scoreboard_inc(METS_SENT_ALL);
       return EXIT_SUCCESS;
 
   } else {
@@ -206,6 +209,8 @@ push_data_to_carbon( char *graphite_msg)
              err_msg("sendto socket (client): %s", strerror(errno));
              return EXIT_FAILURE;
       }
+      ganglia_scoreboard_inc(METS_SENT_GRAPHITE);
+      ganglia_scoreboard_inc(METS_SENT_ALL);
       return EXIT_SUCCESS;
   }
 }
@@ -244,6 +249,8 @@ write_data_to_memcached ( const char *cluster, const char *host, const char *met
    } else {
       debug_msg("Pushed %s value %s to the memcached server(s)", s_path, sum);
       memcached_pool_push(memcached_connection_pool, memc);
+      ganglia_scoreboard_inc(METS_SENT_MEMCACHED);
+      ganglia_scoreboard_inc(METS_SENT_ALL);
       return EXIT_SUCCESS;
    }
 }
@@ -535,6 +542,9 @@ send_data_to_riemann (const char *grid, const char *cluster, const char *host, c
   free(buf);
 
   pthread_mutex_unlock( &riemann_mutex );
+
+  ganglia_scoreboard_inc(METS_SENT_RIEMANN);
+  ganglia_scoreboard_inc(METS_SENT_ALL);
 
   return EXIT_SUCCESS;
 

--- a/gmetad/gmetad.c
+++ b/gmetad/gmetad.c
@@ -14,12 +14,14 @@
 
 #include "daemon_init.h"
 #include "update_pidfile.h"
+#include "gm_scoreboard.h"
 
 #include "rrd_helpers.h"
 #include "export_helpers.h"
 
 #define METADATA_SLEEP_RANDOMIZE 5.0
 #define METADATA_MINIMUM_SLEEP 1
+#define HOSTNAMESZ 64
 
 /* Holds our data sources. */
 hash_t *sources;
@@ -52,6 +54,14 @@ static int debug_level;
 
 /* In cleanup.c */
 extern void *cleanup_thread(void *arg);
+
+/* The global context */
+apr_pool_t *global_context = NULL;
+
+/* When this gmetad was started */
+apr_time_t started;
+
+char hostname[HOSTNAMESZ];
 
 static int
 print_sources ( datum_t *key, datum_t *val, void *arg )
@@ -242,6 +252,18 @@ do_root_summary( datum_t *key, datum_t *val, void *arg )
    return rc;
 }
 
+void initialize_scoreboard()
+{
+    ganglia_scoreboard_init(global_context);
+    ganglia_scoreboard_add(METS_RECVD_ALL, GSB_COUNTER);
+    ganglia_scoreboard_add(METS_SENT_ALL, GSB_COUNTER);
+    ganglia_scoreboard_add(METS_SENT_RRDTOOL, GSB_COUNTER);
+    ganglia_scoreboard_add(METS_SENT_RRDCACHED, GSB_COUNTER);
+    ganglia_scoreboard_add(METS_SENT_GRAPHITE, GSB_COUNTER);
+    ganglia_scoreboard_add(METS_SENT_MEMCACHED, GSB_COUNTER);
+    ganglia_scoreboard_add(METS_SENT_RIEMANN, GSB_COUNTER);
+
+}
 
 static int
 write_root_summary(datum_t *key, datum_t *val, void *arg)
@@ -295,11 +317,10 @@ write_root_summary(datum_t *key, datum_t *val, void *arg)
    return 0;
 }
 
-#define HOSTNAMESZ 64
-
 int
 main ( int argc, char *argv[] )
 {
+   int rc;
    struct stat struct_stat;
    pthread_t pid;
    pthread_attr_t attr;
@@ -308,15 +329,27 @@ main ( int argc, char *argv[] )
    mode_t rrd_umask;
    char * gmetad_username;
    struct passwd *pw;
-   char hostname[HOSTNAMESZ];
    gmetad_config_t *c = &gmetad_config;
    apr_interval_time_t sleep_time;
    apr_time_t last_metadata;
    double random_sleep_factor;
    unsigned int rand_seed;
 
+   rc = apr_initialize();
+   if (rc != APR_SUCCESS) {
+      return -1;
+   }
+
+   /* create a memory pool. */
+   apr_pool_create(&global_context, NULL);
+
    /* Ignore SIGPIPE */
    signal( SIGPIPE, SIG_IGN );
+
+   initialize_scoreboard();
+
+   /* Mark the time this gmetad started */
+   started = apr_time_now();
 
    if (cmdline_parser(argc, argv, &args_info) != 0)
       err_quit("command-line parser error");
@@ -537,5 +570,8 @@ main ( int argc, char *argv[] )
          last_metadata = apr_time_now();
       }
 
+   apr_pool_destroy(global_context);
+
+   apr_terminate();
    return 0;
 }

--- a/gmetad/process_xml.c
+++ b/gmetad/process_xml.c
@@ -5,6 +5,7 @@
 #include <expat.h>
 #include <ganglia.h>
 #include "gmetad.h"
+#include "gm_scoreboard.h"
 #include "rrd_helpers.h"
 #include "export_helpers.h"
 
@@ -775,6 +776,7 @@ startElement_METRIC(void *data, const char *el, const char **attr)
          rdatum = hash_insert(&hashkey, &hashval, summary);
          if (!rdatum) err_msg("Could not insert %s metric", name);
       }
+   ganglia_scoreboard_inc(METS_RECVD_ALL);
    return 0;
 }
 

--- a/gmetad/rrd_helpers.c
+++ b/gmetad/rrd_helpers.c
@@ -17,6 +17,7 @@
 #include <sys/poll.h>
 
 #include "rrd_helpers.h"
+#include "gm_scoreboard.h"
 
 #define PATHSIZE 4096
 extern gmetad_config_t gmetad_config;
@@ -332,10 +333,14 @@ push_data_to_rrd( char *rrd, const char *sum, const char *num,
       }
    if (gmetad_config.rrdcached_addrstr != NULL)
       {
+         ganglia_scoreboard_inc(METS_SENT_RRDCACHED);
+         ganglia_scoreboard_inc(METS_SENT_ALL);
          return RRD_update_cached( rrd, sum, num, process_time );
       }
    else
       {
+         ganglia_scoreboard_inc(METS_SENT_RRDTOOL);
+         ganglia_scoreboard_inc(METS_SENT_ALL);
          return RRD_update( rrd, sum, num, process_time );
       }
 }

--- a/lib/gm_scoreboard.h
+++ b/lib/gm_scoreboard.h
@@ -13,7 +13,16 @@ enum ganglia_scoreboard_types {
 };
 typedef enum ganglia_scoreboard_types ganglia_scoreboard_types;
 
-/* predefined scoreboard elements */
+/* predefined gmetad scoreboard elements */
+#define METS_RECVD_ALL "gmetad_metrics_recvd_all"
+#define METS_SENT_ALL "gmetad_metrics_sent_all"
+#define METS_SENT_RRDTOOL "gmetad_metrics_sent_rrdtool"
+#define METS_SENT_RRDCACHED "gmetad_metrics_sent_rrdcached"
+#define METS_SENT_GRAPHITE "gmetad_metrics_sent_graphite"
+#define METS_SENT_MEMCACHED "gmetad_metrics_sent_memcached"
+#define METS_SENT_RIEMANN "gmetad_metrics_sent_riemann"
+
+/* predefined gmond scoreboard elements */
 #define PKTS_RECVD_ALL "gmond_pkts_recvd_all"
 #define PKTS_RECVD_FAILED "gmond_pkts_recvd_failed"
 #define PKTS_RECVD_IGNORED "gmond_pkts_recvd_ignored"


### PR DESCRIPTION
Add internal gmetad metrics similar to the internal gmond metrics currently available. Metrics are returned if the interactive port 8652 is polled with "/status" or "GET /status HTTP/1.0". The configure options `--enable-status` needs to be supplied to make these metrics availabe. eg. `./conifgure --with-gmetad --enable-status`

The server info and metrics collected so far...

```
{
  host: "vagrant-ubuntu-raring-64",
  gridname: "unspecified",
  version: "3.6.0-1",
  boottime: 1392590058909,
  uptime: 661,
  uptimeMillis: 661720,
  metrics: {
    received: {
      all: 1485
    },
    sent: {
      all: 6438,
      rrdtool: 0,
      rrdcached: 5133,
      graphite: 1305,
      memcached: 0,
      riemann: 0
    }
  }
}
```

suggestions for other metrics to collect or changes to the above are welcome.
