### PR TITLE
Bug fixes

### DIFF
--- a/gmond/gmond.c
+++ b/gmond/gmond.c
@@ -3297,6 +3297,7 @@ main ( int argc, char *argv[] )
   apr_signal( SIGPIPE, SIG_IGN );
   apr_signal( SIGINT, sig_handler );
   apr_signal( SIGHUP, sig_handler );
+  apr_signal( SIGTERM, sig_handler );
 
   initialize_scoreboard();
 


### PR DESCRIPTION
1) Fix memory leak when metric expires. The metadata metric is deleted
properly, but the value metric is not.
2) Memory leak because global_context is not destroyed before reloading
config.
3) Fix errornous handling of zip content. apr_socket_data_get()
returns APR_SUCCESS if GZIP_KEY is not present, but strm will 
be NULL and cause a seg-fault in line 275.
