### PR TITLE
add incby(n,v) to ganglia scoreboard and change type to unsigned

### DIFF
--- a/lib/gm_scoreboard.h
+++ b/lib/gm_scoreboard.h
@@ -46,6 +46,7 @@ int ganglia_scoreboard_get(char *name);
 void ganglia_scoreboard_set(char *name, int val);
 void ganglia_scoreboard_reset(char *name);
 int ganglia_scoreboard_inc(char *name);
+int ganglia_scoreboard_incby(char *name, int val);
 void ganglia_scoreboard_dec(char *name);
 ganglia_scoreboard_types ganglia_scoreboard_type(char *name);
 #else
@@ -57,6 +58,7 @@ ganglia_scoreboard_types ganglia_scoreboard_type(char *name);
 #define ganglia_scoreboard_set(n,v) 
 #define ganglia_scoreboard_reset(n) 
 #define ganglia_scoreboard_inc(n)
+#define ganglia_scoreboard_incby(n,v)
 #define ganglia_scoreboard_dec(n) 
 #define ganglia_scoreboard_type(n) (GSB_UNKNOWN)
 #endif

--- a/lib/scoreboard.c
+++ b/lib/scoreboard.c
@@ -17,7 +17,7 @@
 struct gsb_element {
   ganglia_scoreboard_types type;
   char *name;
-  int val;
+  unsigned val;
 };
 typedef struct gsb_element gsb_element;
 
@@ -139,6 +139,22 @@ int ganglia_scoreboard_inc(char *name)
         gsb_element *element = get_scoreboard_element(name);
         if (element && (element->type != GSB_STATE)) {
             element->val++;
+            retval = element->val;
+        }
+    }
+    else {
+        err_msg(GSB_ERROR_MSG);
+    }
+    return retval;
+}
+
+int ganglia_scoreboard_incby(char *name, int val)
+{
+    int retval = 0;
+    if (gsb_scoreboard) {
+        gsb_element *element = get_scoreboard_element(name);
+        if (element && (element->type != GSB_STATE)) {
+            element->val += val;
             retval = element->val;
         }
     }


### PR DESCRIPTION
add incby(n,v) to ganglia scoreboard for incrementing by a number

also, change the type from int to unsigned because overflow of
signed integers is undefined. This should not effect existing
metrics for ganglia agents because they are reset-on-read.

See http://stackoverflow.com/questions/18195715
