### PR TITLE
converting hostnames to lowercase

### DIFF
--- a/gmetad/process_xml.c
+++ b/gmetad/process_xml.c
@@ -455,9 +455,9 @@ startElement_HOST(void *data, const char *el, const char **attr)
    /* Convert name to lower case - host names can't be
     * case sensitive
     */
-   /*for(i = 0; name[i] != 0; i++)
+   for(i = 0; name[i] != 0; i++)
        xmldata->hostname[i] = tolower(name[i]);
-   xmldata->hostname[i] = 0; */
+   xmldata->hostname[i] = 0;
 
    hashkey.data = (void*) name;
    hashkey.size =  strlen(name) + 1;


### PR DESCRIPTION
Case-insensitive handling of hostnames in lib/hash.c was removed in this commit https://github.com/ganglia/monitor-core/commit/02524bf2f5485cfd4cddb66bd3280e5a08a2232c

This leads to "HOSTNAME" and "hostname" being two separate keys in the hashtable. 

Hostnames are converted to lowercase when the path to the rrd file is constructed in write_data_to_rrd (gmetad/process_xml.c) so the aggregated data will likely end up in the same .rrd file anyway. However, it's more efficient to handle the hostnames in a case-insensitive manner first.
