### PR TITLE
Restart daemons after updating, gmond hash table locking (for master)

### DIFF
--- a/ganglia.spec.in
+++ b/ganglia.spec.in
@@ -260,6 +260,12 @@ then
 %endif
 fi
 
+%postun gmetad
+if [ "$1" -ge 1 ]
+then
+   /etc/init.d/gmetad condrestart
+fi
+
 #%preun gmetad-python
 #if [ "$1" = 0 ]
 #then
@@ -277,6 +283,12 @@ then
    /etc/init.d/gmond stop
    /sbin/chkconfig --del gmond
 %endif
+fi
+
+%postun gmond
+if [ "$1" -ge 1 ]
+then
+   /etc/init.d/gmond condrestart
 fi
 
 %post   -n libganglia -p /sbin/ldconfig

--- a/ganglia.spec.in
+++ b/ganglia.spec.in
@@ -177,7 +177,7 @@ gmetad packages
 %build
 %configure --with-gmetad --enable-status --sysconfdir=%{conf_dir}
 %ifnarch noarch
-make
+%__make
 %endif
 #cd gmetad-python
 #%{__python} setup.py build

--- a/gmetad/gmetad.init
+++ b/gmetad/gmetad.init
@@ -11,39 +11,82 @@ test -f /etc/sysconfig/gmetad && . /etc/sysconfig/gmetad
 
 export RRDCACHED_ADDRESS
 
-RETVAL=0
+start() {
+    [ -x $GMETAD ] || exit 5
+    [ -f /etc/ganglia/gmetad.conf ] || exit 6
+    echo -n "Starting GANGLIA gmetad: "
+    daemon $GMETAD
+    RETVAL=$?
+    echo
+    [ $RETVAL -eq 0 ] && touch /var/lock/subsys/gmetad
+    return $RETVAL
+}
+
+stop() {
+    echo -n "Shutting down GANGLIA gmetad: "
+    killproc $GMETAD
+    RETVAL=$?
+    echo
+    [ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/gmetad
+    return $RETVAL
+}
+
+restart() {
+    stop
+    start
+}
+
+reload() {
+    restart
+}
+
+force_reload() {
+    restart
+}
+
+rh_status() {
+    status $GMETAD
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+usage() {
+    echo "Usage: $0 {start|stop|status|restart|condrestart|try-restart|reload|force-reload}"
+}
 
 case "$1" in
-   start)
-      echo -n "Starting GANGLIA gmetad: "
-      [ -f $GMETAD ] || exit 1
-
-      daemon $GMETAD
-      RETVAL=$?
-      echo
-      [ $RETVAL -eq 0 ] && touch /var/lock/subsys/gmetad
-      ;;
-
-  stop)
-      echo -n "Shutting down GANGLIA gmetad: "
-      killproc $GMETAD
-      RETVAL=$?
-      echo
-      [ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/gmetad
-      ;;
-
-  restart|reload)
-      $0 stop
-      $0 start
-      RETVAL=$?
-      ;;
-  status)
-      status $GMETAD
-      RETVAL=$?
-      ;;
-  *)
-      echo "Usage: $0 {start|stop|restart|status}"
-      exit 1
+    start)
+	rh_status_q && exit 0
+	$1
+	;;
+    stop)
+	rh_status_q || exit 1
+	$1
+	;;
+    restart)
+	$1
+	;;
+    reload)
+	rh_status_q || exit 7
+	$1
+	;;
+    force-reload)
+	force_reload
+	;;
+    status)
+	rh_status
+	;;
+    condrestart|try-restart)
+	rh_status_q || exit 0
+	restart
+	;;
+    usage)
+	$1
+	;;
+    *)
+	usage
+	exit 2
 esac
-
-exit $RETVAL
+exit $?

--- a/gmond/gmond.c
+++ b/gmond/gmond.c
@@ -1038,7 +1038,9 @@ Ganglia_host_get( char *remIP, apr_sockaddr_t *sa, Ganglia_metric_id *metric_id)
       remoteip = spoofIP;
     }
 
+  apr_thread_mutex_lock(hosts_mutex);
   hostdata =  (Ganglia_host *)apr_hash_get( hosts, remoteip, APR_HASH_KEY_STRING );
+  apr_thread_mutex_unlock(hosts_mutex);
   if(!hostdata)
     {
       /* Lookup the hostname or use the proxy information if available */
@@ -1179,8 +1181,11 @@ Ganglia_metadata_check(Ganglia_host *host, Ganglia_value_msg *vmsg )
 {
     char *metric_name = vmsg->Ganglia_value_msg_u.gstr.metric_id.name;
     int is_spoof_msg = vmsg->Ganglia_value_msg_u.gstr.metric_id.spoof;
-    Ganglia_metadata *metric = 
-        (Ganglia_metadata *)apr_hash_get(host->metrics, metric_name, APR_HASH_KEY_STRING);
+    Ganglia_metadata *metric;
+
+    apr_thread_mutex_lock(host->mutex);
+    metric = (Ganglia_metadata *)apr_hash_get(host->metrics, metric_name, APR_HASH_KEY_STRING);
+    apr_thread_mutex_unlock(host->mutex);
     
     if(!metric)
       {
@@ -1230,14 +1235,19 @@ Ganglia_metadata_free( Ganglia_metadata *metric )
 void
 Ganglia_metadata_save( Ganglia_host *host, Ganglia_metadata_msg *message )
 {
-    /* Search for the Ganglia_metadata in the Ganglia_host */
-    sanitize_metric_name(message->Ganglia_metadata_msg_u.gfull.metric_id.name, message->Ganglia_metadata_msg_u.gfull.metric_id.spoof);
-    Ganglia_metadata *metric = 
-        (Ganglia_metadata *)apr_hash_get(host->metrics, 
-                                         message->Ganglia_metadata_msg_u.gfull.metric_id.name,
-                                         APR_HASH_KEY_STRING);
+    Ganglia_metadata *metric;
+
     if(!host || !message)
         return;
+
+    /* Search for the Ganglia_metadata in the Ganglia_host */
+    sanitize_metric_name(message->Ganglia_metadata_msg_u.gfull.metric_id.name, message->Ganglia_metadata_msg_u.gfull.metric_id.spoof);
+
+    apr_thread_mutex_lock(host->mutex);
+    metric = (Ganglia_metadata *)apr_hash_get(host->metrics,
+                                              message->Ganglia_metadata_msg_u.gfull.metric_id.name,
+                                              APR_HASH_KEY_STRING);
+    apr_thread_mutex_unlock(host->mutex);
     
     if(metric)
       {
@@ -1340,13 +1350,17 @@ Ganglia_metadata_request( Ganglia_host *host, Ganglia_metadata_msg *message )
 void
 Ganglia_value_save( Ganglia_host *host, Ganglia_value_msg *message )
 {
-    /* Search for the Ganglia_metric in the Ganglia_host */
-    Ganglia_metadata *metric = 
-        (Ganglia_metadata *)apr_hash_get( host->gmetrics,
-                                        message->Ganglia_value_msg_u.gstr.metric_id.name,
-                                        APR_HASH_KEY_STRING);
+  Ganglia_metadata *metric;
+
   if(!host || !message)
     return;
+
+  /* Search for the Ganglia_metric in the Ganglia_host */
+  apr_thread_mutex_lock(host->mutex);
+  metric = (Ganglia_metadata *)apr_hash_get(host->gmetrics,
+                                            message->Ganglia_value_msg_u.gstr.metric_id.name,
+                                            APR_HASH_KEY_STRING);
+  apr_thread_mutex_unlock(host->mutex);
 
   if(metric)
     {
@@ -3144,6 +3158,7 @@ cleanup_data( apr_pool_t *pool, apr_time_t now )
   apr_hash_index_t *hi, *metric_hi;
 
   /* Walk the host hash */
+  apr_thread_mutex_lock(hosts_mutex);
   for(hi = apr_hash_first(pool, hosts);
       hi;
       hi = apr_hash_next(hi))
@@ -3158,9 +3173,7 @@ cleanup_data( apr_pool_t *pool, apr_time_t now )
           /* this host is older than dmax... delete it */
           debug_msg("deleting old host '%s' from host hash'", host->hostname);
           /* remove it from the hash */
-          apr_thread_mutex_lock(hosts_mutex);
           apr_hash_set( hosts, host->ip, APR_HASH_KEY_STRING, NULL);
-          apr_thread_mutex_unlock(hosts_mutex);
           /* free all its memory */
           if(host->location)
           {
@@ -3171,6 +3184,7 @@ cleanup_data( apr_pool_t *pool, apr_time_t now )
       else
         {
           /* this host isn't being deleted but it might have some stale gmetric data */
+	  apr_thread_mutex_lock(host->mutex);
           for( metric_hi = apr_hash_first( pool, host->metrics );
                metric_hi;
                metric_hi = apr_hash_next( metric_hi ))
@@ -3195,10 +3209,8 @@ cleanup_data( apr_pool_t *pool, apr_time_t now )
                   debug_msg("deleting old metric '%s' from host '%s'", metric->name, host->hostname);
 
                   /* remove the metric from the metric and values hash */
-                  apr_thread_mutex_lock(host->mutex);
                   apr_hash_set( host->metrics, metric->name, APR_HASH_KEY_STRING, NULL);
                   apr_hash_set( host->gmetrics, metric->name, APR_HASH_KEY_STRING, NULL);
-                  apr_thread_mutex_unlock(host->mutex);
                   /* destroy any memory that was allocated for this gmetric */
                   apr_pool_destroy( metric->pool );
                   if (value_metric)
@@ -3207,8 +3219,10 @@ cleanup_data( apr_pool_t *pool, apr_time_t now )
                   }
                 }
             }
+	  apr_thread_mutex_unlock(host->mutex);
         }
     }
+  apr_thread_mutex_unlock(hosts_mutex);
 
   apr_pool_clear( pool );
 }

--- a/gmond/gmond.init
+++ b/gmond/gmond.init
@@ -11,39 +11,82 @@ export TMPDIR
 
 . /etc/rc.d/init.d/functions
 
-RETVAL=0
+start() {
+    [ -x $GMOND ] || exit 5
+    [ -f /etc/ganglia/gmond.conf ] || exit 6
+    echo -n "Starting GANGLIA gmond: "
+    daemon $GMOND
+    RETVAL=$?
+    echo
+    [ $RETVAL -eq 0 ] && touch /var/lock/subsys/gmond
+    return $RETVAL
+}
+
+stop() {
+    echo -n "Shutting down GANGLIA gmond: "
+    killproc gmond
+    RETVAL=$?
+    echo
+    [ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/gmond
+    return $RETVAL
+}
+
+restart() {
+    stop
+    start
+}
+
+reload() {
+    restart
+}
+
+force_reload() {
+    restart
+}
+
+rh_status() {
+    status $GMOND
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+usage() {
+    echo "Usage: $0 {start|stop|status|restart|condrestart|try-restart|reload|force-reload}"
+}
 
 case "$1" in
-   start)
-      echo -n "Starting GANGLIA gmond: "
-      [ -f $GMOND ] || exit 1
-
-      daemon $GMOND
-      RETVAL=$?
-      echo
-      [ $RETVAL -eq 0 ] && touch /var/lock/subsys/gmond
+    start)
+	rh_status_q && exit 0
+	$1
 	;;
-
-  stop)
-      echo -n "Shutting down GANGLIA gmond: "
-      killproc gmond
-      RETVAL=$?
-      echo
-      [ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/gmond
+    stop)
+	rh_status_q || exit 1
+	$1
 	;;
-
-  restart|reload)
-   	$0 stop
-   	$0 start
-   	RETVAL=$?
+    restart)
+	$1
 	;;
-  status)
-   	status gmond
-   	RETVAL=$?
+    reload)
+	rh_status_q || exit 7
+	$1
 	;;
-  *)
-	echo "Usage: $0 {start|stop|restart|status}"
-	exit 1
+    force-reload)
+	force_reload
+	;;
+    status)
+	rh_status
+	;;
+    condrestart|try-restart)
+	rh_status_q || exit 0
+	restart
+	;;
+    usage)
+	$1
+	;;
+    *)
+	usage
+	exit 2
 esac
-
-exit $RETVAL
+exit $?


### PR DESCRIPTION
I pushed a new version of the ganglia rpms to test a fix for the locking issue I've mentioned on the ganglia-developer's list.  In the process, I discovered that the rpm upgrade process didn't restart the newly updated daemons.  

I've cherry-picked these changes from my release/3.6 branch, as it also has my gmond lock fixes.  I'm holding off on that pull request until it has a bit more test time..