### PR TITLE
Adding e2fsprogs-devel to the BuildRequires for RHEL5.

### DIFF
--- a/ganglia.spec.in
+++ b/ganglia.spec.in
@@ -34,6 +34,11 @@ BuildRequires: rrdtool, expat
 %else
 BuildRequires: expat-devel, rrdtool-devel, freetype-devel, apr-devel > 1
 %endif
+
+%if 0%{?rhel} == 5
+BuildRequires: e2fsprogs-devel
+%endif
+
 %define conf_dir /etc/ganglia
 %define gmond_conf %{_builddir}/%{?buildsubdir}/gmond/gmond.conf
 %define generate_gmond_conf %(test -e %gmond_conf && echo 0 || echo 1)


### PR DESCRIPTION
Hi,

I have found that I needed to have e2fsprogs-devel installed for ganglia to build on RHEL5 or in an EPEL5 mock environment.

The attached patch adds this as a BuildRequires.

Cheers,
RobbieAB.