### PR TITLE
Switch from CK rwlocks to APR rwlocks

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -11,7 +11,6 @@ Dependencies
 * python (http://www.python.org/)
 * PCRE (http://www.pcre.org/)
 * RRDtool (http://oss.oetiker.ch/rrdtool/)
-* CK (http://concurrencykit.org/)
 
 Basic Installation
 ==================

--- a/configure.ac
+++ b/configure.ac
@@ -614,8 +614,6 @@ AC_CHECK_HEADER([rpc/xdr.h], [],
 #endif
 ])
 
-PKG_CHECK_MODULES([CK], [ck])
-
 dnl ##################################################################
 dnl Checks for typedefs.
 dnl

--- a/gmetad/Makefile.am
+++ b/gmetad/Makefile.am
@@ -12,7 +12,7 @@ GLDFLAGS =
 endif
 
 INCLUDES = @APR_INCLUDES@
-AM_CFLAGS = -I$(top_builddir)/lib -I$(top_builddir)/gmond -I$(top_builddir)/libmetrics -I$(top_builddir)/include $(GCFLAGS) @CK_CFLAGS@ @PROTOBUF_C_CFLAGS@
+AM_CFLAGS = -I$(top_builddir)/lib -I$(top_builddir)/gmond -I$(top_builddir)/libmetrics -I$(top_builddir)/include $(GCFLAGS) @PROTOBUF_C_CFLAGS@
 
 sbin_PROGRAMS = gmetad
 
@@ -31,7 +31,7 @@ endif
 
 gmetad_LDADD   = $(top_builddir)/lib/libganglia.la -lrrd -lm \
                  $(top_builddir)/libmetrics/libmetrics.la \
-                 $(GLDADD) $(DEPS_LIBS) @CK_LIBS@ @PROTOBUF_C_LIBS@
+                 $(GLDADD) $(DEPS_LIBS) @PROTOBUF_C_LIBS@
 
 gmetad_LDFLAGS = $(GLDFLAGS)
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -15,7 +15,7 @@ GCFLAGS += -DSFLOW
 endif
 
 INCLUDES = @APR_INCLUDES@
-AM_CFLAGS = -I.. -I. -I$(top_builddir)/include/ $(GCFLAGS) -DSYSCONFDIR='"$(sysconfdir)"' @CK_CFLAGS@
+AM_CFLAGS = -I.. -I. -I$(top_builddir)/include/ $(GCFLAGS) -DSYSCONFDIR='"$(sysconfdir)"'
 
 include_HEADERS = gm_protocol.h
 
@@ -36,7 +36,7 @@ libganglia_la_LDFLAGS = \
 	-export-dynamic \
 	$(GLDFLAGS)
 
-libganglia_la_LIBADD = $(GLDADD) @CK_LIBS@
+libganglia_la_LIBADD = $(GLDADD)
 
 noinst_LIBRARIES = libgetopthelper.a
 # A little helper for getopt functions

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -3,7 +3,7 @@
 #include <string.h>
 #include <stdlib.h>
 
-#include <ck_rwlock.h>
+#include <apr_thread_rwlock.h>
 
 #include "hash.h"
 #include "ganglia.h"
@@ -60,7 +60,9 @@ datum_free (datum_t *datum)
 hash_t *
 hash_create (size_t size)
 {
+   apr_status_t status;
    hash_t *hash;
+   size_t i;
 
    debug_msg("hash_create size = %zd", size);
 
@@ -94,18 +96,25 @@ hash_create (size_t size)
          return NULL;
       }
 
-   hash->lock = calloc(hash->size, sizeof (*hash->lock));
-   if (hash->lock == NULL) 
+   status = apr_pool_create(&hash->lockpool, NULL);
+   if (status != APR_SUCCESS)
       {
-         debug_msg("hash->lock malloc error. freeing hash.");
+         debug_msg("lock pool failed, freeing hash.");
          free(hash);
          return NULL;
       }
-   /*
-    * ck_rwlock_init just sets things to zero and does a memory fence. calloc 
-    * already set zero, so add mfence only.
-    */
-   ck_pr_fence_memory();
+
+   for (i = 0; i < size; i++)
+      {
+         status = apr_thread_rwlock_create(&(hash->lock[i]), hash->lockpool);
+         if (status != APR_SUCCESS)
+            {
+               debug_msg("Error initializing locks.");
+               apr_pool_destroy(hash->lockpool);
+               free(hash);
+               return NULL;
+            }
+      }
 
    return hash;
 }
@@ -190,7 +199,7 @@ hash_insert (datum_t *key, datum_t *val, hash_t *hash)
 
   i = hashval(key, hash);
 
-  ck_rwlock_write_lock(&hash->lock[i]);
+  apr_thread_rwlock_wrlock(hash->lock[i]);
 
   bucket = &hash->node[i];
   if (bucket->key == NULL)
@@ -201,7 +210,7 @@ hash_insert (datum_t *key, datum_t *val, hash_t *hash)
            {
               free(bucket);
               bucket = NULL;
-              ck_rwlock_write_unlock(&hash->lock[i]);
+              apr_thread_rwlock_unlock(hash->lock[i]);
               return NULL;
            } 
         bucket->val = datum_dup(val);
@@ -209,10 +218,10 @@ hash_insert (datum_t *key, datum_t *val, hash_t *hash)
            {
               free(bucket);
               bucket = NULL;
-              ck_rwlock_write_unlock(&hash->lock[i]);
+              apr_thread_rwlock_unlock(hash->lock[i]);
               return NULL;
            }
-        ck_rwlock_write_unlock(&hash->lock[i]);
+        apr_thread_rwlock_unlock(hash->lock[i]);
         return bucket->val;
      }
 
@@ -231,7 +240,7 @@ hash_insert (datum_t *key, datum_t *val, hash_t *hash)
                      /* Make sure we have enough room */
                      if(! (bucket->val->data = realloc(bucket->val->data, val->size)) )
                         {
-                           ck_rwlock_write_unlock(&hash->lock[i]);
+                           apr_thread_rwlock_unlock(hash->lock[i]);
                            return NULL;
                         }
                      bucket->val->size = val->size;
@@ -239,7 +248,7 @@ hash_insert (datum_t *key, datum_t *val, hash_t *hash)
 
                memset( bucket->val->data, 0, val->size );
                memcpy( bucket->val->data, val->data, val->size );
-               ck_rwlock_write_unlock(&hash->lock[i]);
+               apr_thread_rwlock_unlock(hash->lock[i]);
                return bucket->val;
             }
       }
@@ -248,14 +257,14 @@ hash_insert (datum_t *key, datum_t *val, hash_t *hash)
   bucket = calloc(1, sizeof(*bucket));
   if (bucket == NULL)
      {
-        ck_rwlock_write_unlock(&hash->lock[i]);
+        apr_thread_rwlock_unlock(hash->lock[i]);
         return NULL;
      }
   bucket->key = datum_dup (key);
   if ( bucket->key == NULL )
      {
         free(bucket);
-        ck_rwlock_write_unlock(&hash->lock[i]);
+        apr_thread_rwlock_unlock(hash->lock[i]);
         return NULL;
      }
   bucket->val = datum_dup (val);
@@ -263,14 +272,14 @@ hash_insert (datum_t *key, datum_t *val, hash_t *hash)
      {
         datum_free(bucket->key);
         free(bucket);
-        ck_rwlock_write_unlock(&hash->lock[i]);
+        apr_thread_rwlock_unlock(hash->lock[i]);
         return NULL;
      }  
 
   
   bucket->next = hash->node[i].next;
   hash->node[i].next = bucket;
-  ck_rwlock_write_unlock(&hash->lock[i]);
+  apr_thread_rwlock_unlock(hash->lock[i]);
   return bucket->val;
 }
 
@@ -283,13 +292,13 @@ hash_lookup (datum_t *key, hash_t * hash)
 
   i = hashval(key, hash);
 
-  ck_rwlock_read_lock(&hash->lock[i]);
+  apr_thread_rwlock_rdlock(hash->lock[i]);
 
   bucket = &hash->node[i];
 
   if ( bucket == NULL )
      {
-        ck_rwlock_read_unlock(&hash->lock[i]);
+        apr_thread_rwlock_unlock(hash->lock[i]);
         return NULL;
      }
 
@@ -298,12 +307,12 @@ hash_lookup (datum_t *key, hash_t * hash)
       if (bucket->key && hash_keycmp(hash, key, bucket->key))
          {
             val =  datum_dup( bucket->val );
-            ck_rwlock_read_unlock(&hash->lock[i]);
+            apr_thread_rwlock_unlock(hash->lock[i]);
             return val;
          }
     }
 
-  ck_rwlock_read_unlock(&hash->lock[i]);
+  apr_thread_rwlock_unlock(hash->lock[i]);
   return NULL;
 }
 
@@ -315,12 +324,12 @@ hash_delete (datum_t *key, hash_t * hash)
 
   i = hashval(key,hash);
 
-  ck_rwlock_write_lock(&hash->lock[i]);
+  apr_thread_rwlock_wrlock(hash->lock[i]);
 
   bucket = &hash->node[i];
   if (bucket->key == NULL )
      {
-        ck_rwlock_write_unlock(&hash->lock[i]);
+        apr_thread_rwlock_unlock(hash->lock[i]);
         return NULL;
      }
 
@@ -344,7 +353,7 @@ hash_delete (datum_t *key, hash_t * hash)
             }
 
           datum_free(tmp.key);
-          ck_rwlock_write_unlock(&hash->lock[i]);
+          apr_thread_rwlock_unlock(hash->lock[i]);
         }
       else
         {
@@ -352,13 +361,13 @@ hash_delete (datum_t *key, hash_t * hash)
           datum_free(bucket->key);
           tmp.val = bucket->val;
           free(bucket);
-          ck_rwlock_write_unlock(&hash->lock[i]);
+          apr_thread_rwlock_unlock(hash->lock[i]);
         }
 
       return tmp.val;
     }
 
-  ck_rwlock_write_unlock(&hash->lock[i]);
+  apr_thread_rwlock_unlock(hash->lock[i]);
   return NULL;
 }
 
@@ -376,14 +385,14 @@ hash_walkfrom (hash_t * hash, size_t from,
 
   for (i = from; i < hash->size && !stop; i++)
     {
-       ck_rwlock_read_lock(&hash->lock[i]);
+       apr_thread_rwlock_rdlock(hash->lock[i]);
        for (bucket = &hash->node[i]; bucket != NULL && bucket->key != NULL; bucket = bucket->next)
          {
            if (bucket->key == NULL) continue;
            stop = func(bucket->key, bucket->val, arg);
            if (stop) break;
          }
-       ck_rwlock_read_unlock(&hash->lock[i]);
+       apr_thread_rwlock_unlock(hash->lock[i]);
     }
   return stop;
 }
@@ -397,14 +406,14 @@ hash_foreach (hash_t * hash, int (*func)(datum_t *, datum_t *, void *), void *ar
 
   for (i = 0; i < hash->size && !stop; i++)
     {
-       ck_rwlock_read_lock(&hash->lock[i]);
+       apr_thread_rwlock_rdlock(hash->lock[i]);
        for (bucket = &hash->node[i]; bucket != NULL && bucket->key != NULL; bucket = bucket->next)
          {
            if (bucket->key == NULL) continue;
            stop = func(bucket->key, bucket->val, arg);
            if (stop) break;
          }
-       ck_rwlock_read_unlock(&hash->lock[i]);
+       apr_thread_rwlock_unlock(hash->lock[i]);
     }
   return stop;
 }

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -96,6 +96,14 @@ hash_create (size_t size)
          return NULL;
       }
 
+   hash->lock = calloc(hash->size, sizeof (*hash->lock));
+   if (hash->lock == NULL)
+      {
+         debug_msg("hash->lock alloc error; freeing hash");
+         free(hash);
+         return NULL;
+      }
+
    status = apr_pool_create(&hash->lockpool, NULL);
    if (status != APR_SUCCESS)
       {
@@ -106,11 +114,12 @@ hash_create (size_t size)
 
    for (i = 0; i < size; i++)
       {
-         status = apr_thread_rwlock_create(&(hash->lock[i]), hash->lockpool);
+         status = apr_thread_rwlock_create(&hash->lock[i], hash->lockpool);
          if (status != APR_SUCCESS)
             {
                debug_msg("Error initializing locks.");
                apr_pool_destroy(hash->lockpool);
+               free(hash->lock);
                free(hash);
                return NULL;
             }

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -2,7 +2,7 @@
 #define HASH__H 1
 
 #include <stddef.h>				  /* For size_t     */
-#include <ck_rwlock.h>
+#include <apr_thread_rwlock.h>
 
 #define HASH_FLAG_IGNORE_CASE 1
 
@@ -24,7 +24,8 @@ node_t;
 
 typedef struct
 {
-   ck_rwlock_t *lock;
+   apr_pool_t *lockpool;
+   apr_thread_rwlock_t **lock;
    size_t size;
    node_t *node;
    int flags;


### PR DESCRIPTION
There is some concern around cutting a 3.7 release with the CK dependency and its (lack of) packaging in major distributions. Additionally, people with large numbers of data sources experience CPU spikes when aggregating even a small number of metrics. This latter point is solvable with a new hash table implementation, but that is a task for a different release.

This changeset removes CK rwlocks and replaces them with APR rwlocks. This should solve the CPU spiking, and since APR was already a dependence, solve the packaging concerns as well.