### PR TITLE
build cpu_stat along with the other python modules

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -892,6 +892,7 @@ AC_OUTPUT(Makefile
           gmond/perl_modules/example/Makefile
           gmond/python_modules/Makefile
           gmond/python_modules/apache_status/Makefile
+          gmond/python_modules/cpu/Makefile
           gmond/python_modules/db/Makefile
           gmond/python_modules/disk/Makefile
           gmond/python_modules/example/Makefile

--- a/gmond/python_modules/Makefile.am
+++ b/gmond/python_modules/Makefile.am
@@ -1,2 +1,2 @@
-DIST_SUBDIRS = apache_status db disk example memcached memory network nfs process ssl varnish vm_stats xen
+DIST_SUBDIRS = apache_status cpu db disk example memcached memory network nfs process ssl varnish vm_stats xen
 EXTRA_DIST = ./conf.d/*.pyconf ./conf.d/*.pyconf.disabled

--- a/gmond/python_modules/cpu/Makefile.am
+++ b/gmond/python_modules/cpu/Makefile.am
@@ -1,0 +1,2 @@
+pys = cpu_stats.py
+EXTRA_DIST = $(pys)


### PR DESCRIPTION
At some point the default set of `pyconf` files and which modules were
actually being built got out of sync.  This meant the cpu python files
were not present but were referenced in a `pyconf` file, resulting in
`Unable to find the metric information for foo` errors when gmond was
started. (And obviously there were no metrics either.)

fix #180