### PR TITLE
dedupe python modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ btool
 **/*.la
 **/*.lo
 *~
+*.pyc
 scripts/fixconfig
 stamp-h1
 lib/default_conf.h

--- a/gmond/python_modules/apache_status/apache_status.py
+++ b/gmond/python_modules/apache_status/apache_status.py
@@ -8,6 +8,11 @@ import urllib2
 import traceback
 import re
 import copy
+import sys
+import socket
+
+if sys.version_info < (2, 6):
+    socket.setdefaulttimeout(2)
 
 # global to store state for "total accesses"
 METRICS = {
@@ -68,7 +73,10 @@ def get_metrics():
             req = urllib2.Request(SERVER_STATUS_URL + "?auto")
             
             # Download the status file
-            res = urllib2.urlopen(req, None, 2)
+            if sys.version_info < (2, 6):
+                res = urllib2.urlopen(req)
+            else:
+                res = urllib2.urlopen(req, timeout=2)
 
             for line in res:
                split_line = line.rstrip().split(": ")
@@ -93,7 +101,10 @@ def get_metrics():
                 req2 = urllib2.Request(SERVER_STATUS_URL)
                 
                 # Download the status file
-                res = urllib2.urlopen(req2, None, 2)
+                if sys.version_info < (2, 6):
+                    res = urllib2.urlopen(req2)
+                else:
+                    res = urllib2.urlopen(req2, timeout=2)
                 
                 for line in res:
                     regMatch = SSL_REGEX.match(line)

--- a/gmond/python_modules/conf.d/apache_status.pyconf.disabled
+++ b/gmond/python_modules/conf.d/apache_status.pyconf.disabled
@@ -3,11 +3,7 @@ modules {
     name     = "apache_status"
     language = "python"
     param url {
-        value = "http://localhost/server-status?auto"
-    }
-
-    param virtual_host {
-        value = "health"
+        value = "http://localhost:7070/server-status"
     }
 
     # Which metric group should these metrics be put into
@@ -15,11 +11,18 @@ modules {
         value = "apache"
     }
 
+    # Collecting SSL metrics under Apache 2.2 appears to cause a memory leak
+    # in mod_status. Watch Apache memory utilization if you enable them
+    param collect_ssl {
+        value = False
+    }
+
+
   }
 }
 
 collection_group {
-  collect_every  = 20
+  collect_every  = 30
   time_threshold = 90
 
   metric {
@@ -90,13 +93,21 @@ collection_group {
 
   metric {
     name  = "ap_rps"
-    title = "Request per second"
+    title = "Requests per second"
     value_threshold = 0.0
   }
-
+  
   metric {
-    name  = "ap_requests"
-    title = "Requests"
+    name  = "ap_cpuload"
+    title = "Pct of time CPU utilized"
     value_threshold = 0.0
-  }
+  }  
+
+#  Uncomment if you are collecting SSL metrics
+#  metric {
+#      name_match = "apssl_(.+)"
+#      value_threshold = 0.0
+#  }
+
+
 }

--- a/gmond/python_modules/conf.d/diskstat.pyconf
+++ b/gmond/python_modules/conf.d/diskstat.pyconf
@@ -7,9 +7,9 @@ modules {
 
     # Specify devices you want to monitor or if empty it will 
     # pick all devices
-    param devices {
-      value = ''
-    }
+    #param devices {
+    #  value = ''
+    #}
 
     #param device-mapper {
     #  value = 'true'

--- a/gmond/python_modules/conf.d/mem_stats.pyconf
+++ b/gmond/python_modules/conf.d/mem_stats.pyconf
@@ -20,6 +20,12 @@ collection_group {
   }
 
   metric {
+    name = "mem_anonpages"
+    title = "AnonPages"
+    value_threshold = 1.0
+  }
+
+  metric {
     name = "mem_mapped"
     title = "Memory Mapped"
     value_threshold = 1.0

--- a/gmond/python_modules/conf.d/memcached.pyconf.disabled
+++ b/gmond/python_modules/conf.d/memcached.pyconf.disabled
@@ -86,6 +86,11 @@ collection_group {
     value_threshold = 0
   }
   metric {
+    name  = "mc_evictions_rate"
+    title = "Rate of valid items removed from cache to free memory for new items"
+    value_threshold = 0
+  }
+  metric {
     name  = "mc_get_hits"
     title = "Number of keys that have been requested and found present "
     value_threshold = 0

--- a/gmond/python_modules/conf.d/redis.pyconf.disabled
+++ b/gmond/python_modules/conf.d/redis.pyconf.disabled
@@ -1,9 +1,10 @@
 modules {
   module {
-    name = "redis"
+    name = "redis-gmond"
     language = "python"
     param host { value = "127.0.0.1" }
     param port { value = 6379 }
+    /* param auth { value = "passwordhere" } */
   }
 }
 collection_group {
@@ -13,14 +14,18 @@ collection_group {
   metric { name = "connected_slaves" }
   metric { name = "blocked_clients" }
   metric { name = "used_memory" }
-  metric { name = "changes_since_last_save" }
-  metric { name = "bgsave_in_progress" }
-  metric { name = "bgrewriteaof_in_progress" }
+  metric { name = "rdb_changes_since_last_save" }
+  metric { name = "rdb_bgsave_in_progress" }
+  metric { name = "master_sync_in_progress" }
+  metric { name = "master_link_status" }
   metric { name = "total_connections_received" }
+  metric { name = "instantaneous_ops_per_sec" }
   metric { name = "total_commands_processed" }
   metric { name = "expired_keys" }
   metric { name = "pubsub_channels" }
   metric { name = "pubsub_patterns" }
-  metric { name = "vm_enabled" }
   metric { name = "master_last_io_seconds_ago" }
+  metric { name = "db0" }
 }
+
+

--- a/gmond/python_modules/conf.d/riak.pyconf.disabled
+++ b/gmond/python_modules/conf.d/riak.pyconf.disabled
@@ -1,120 +1,804 @@
-modules {
+ modules {
+
   module {
+
     name     = "riak"
     language = "python"
     param url {
+
         value = "http://localhost:8098/stats"
     }
   }
 }
 
 collection_group {
+
   collect_every  = 20
   time_threshold = 90
 
+ metric {
+   name = "riak_ignored_gossip_total"
+   title = "Total number of ignored gossip messages since node was started"
+   value_threshold = 0
+}
+  
   metric {
-    name  = "riak_node_get_fsm_time_mean"
-    title = "Mean for riak_kv_get_fsm calls"
-    value_threshold = 0
-  }
+   name = "riak_mem_total"
+   title = "Total available system memory"
+   value_threshold = 0
+}
+
   metric {
-    name  = "riak_ring_creation_size"
-    title = "riak_ring_creation_size"
-    value_threshold = 0
-  }
+   name = "riak_memory_atom"
+   title = "Total amount of memory currently allocated for atom storage"
+   value_threshold = 0
+}
+
   metric {
-    name  = "riak_vnode_puts"
-    title = "Puts handled by local vnodes in the last minute"
-    value_threshold = 0
-  }
+   name = "riak_memory_binary"
+   title = "Total amount of memory used for binaries"
+   value_threshold = 0
+}
+
   metric {
-    name  = "riak_node_get_fsm_time_95"
-    title = "95th percentile for riak_kv_get_fsm calls"
-    value_threshold = 0
-  }
+   name = "riak_memory_code"
+   title = "Total amount of memory allocated for Erlang code"
+   value_threshold = 0
+}
+
   metric {
-    name  = "riak_node_put_fsm_time_mean"
-    title = "Mean for riak_kv_put_fsm calls"
-    value_threshold = 0
-  }
+   name = "riak_memory_processes"
+   title = "Total amount of memory allocated for Erlang processes"
+   value_threshold = 0
+}
+
   metric {
-    name  = "riak_node_put_fsm_time_100"
-    title = "100th percentile for riak_kv_put_fsm calls"
-    value_threshold = 0
-  }
+   name = "riak_memory_processes_used"
+   title = "Total amount of memory used by Erlang processes"
+   value_threshold = 0
+}
+
   metric {
-    name  = "riak_pbc_active"
-    title = "Active pb socket connections"
-    value_threshold = 0
-  }
+   name = "riak_memory_system"
+   title = "Total allocated memory that is not directly related to an Erlang process"
+   value_threshold = 0
+}
+
   metric {
-    name  = "riak_node_get_fsm_time_median"
-    title = "Median for riak_kv_get_fsm calls"
-    value_threshold = 0
-  }
+   name = "riak_memory_total"
+   title = "Total allocated memory (sum of processes and system)"
+   value_threshold = 0
+}
+
   metric {
-    name  = "riak_node_puts"
-    title = "Puts coordinated by this node in the last minute"
-    value_threshold = 0
-  }
+   name = "riak_node_gets_total"
+   title = "Total number of GETs coordinated by this node, including GETs to non-local vnodes"
+   value_threshold = 0
+}
+
   metric {
-    name  = "riak_sys_process_count"
-    title = "riak_sys_process_count"
-    value_threshold = 0
-  }
+   name = "riak_node_puts_total"
+   title = "Total number of PUTs coordinated by this node, including PUTs to non-local vnodes"
+   value_threshold = 0
+}
+
   metric {
-    name  = "riak_node_put_fsm_time_median"
-    title = "Median for riak_kv_put_fsm calls"
-    value_threshold = 0
-  }
+   name = "riak_pbc_connects_total"
+   title = "Total number of Protocol Buffers connections made"
+   value_threshold = 0
+}
+
   metric {
-    name  = "riak_vnode_gets"
-    title = "Gets handled by local vnodes in the last minute"
-    value_threshold = 0
-  }
+   name = "riak_read_repairs_total"
+   title = "Total number of Read Repairs this node has coordinated"
+   value_threshold = 0
+}
+
   metric {
-    name  = "riak_node_get_fsm_time_99"
-    title = "99th percentile for riak_kv_get_fsm calls"
-    value_threshold = 0
-  }
+   name = "riak_riak_kv_vnodeq_total"
+   title = "Total queue size of all local Riak KV virtual nodes in the last minute"
+   value_threshold = 0
+}
+
   metric {
-    name  = "riak_node_get_fsm_time_100"
-    title = "100th percentile for riak_kv_get_fsm calls"
-    value_threshold = 0
-  }
+   name = "riak_riak_pipe_vnodeq_total"
+   title = "Total queue size of all local Riak Pipe virtual nodes in the last minute"
+   value_threshold = 0
+}
+
   metric {
-    name  = "riak_node_put_fsm_time_95"
-    title = "95th percentile for riak_kv_put_fsm calls"
-    value_threshold = 0
-  }
+   name = "riak_riak_search_vnodeq_max"
+   title = "Maximum number of unprocessed messages all virtual node (vnode) message queues in the Riak Search subsystem have received on this node in the last minute"
+   value_threshold = 0
+}
+
   metric {
-    name  = "riak_read_repairs"
-    title = "riak_read_repairs"
-    value_threshold = 0
-  }
+   name = "riak_riak_search_vnodeq_mean"
+   title = "Mean number of unprocessed messages all vnode message queues in the Riak Search subsystem have received on this node in the last minute"
+   value_threshold = 0
+}
+
   metric {
-    name  = "riak_node_gets"
-    title = "Gets coordinated by this node in the last minute"
-    value_threshold = 0
-  }
+   name = "riak_riak_search_vnodeq_median"
+   title = "Median number of unprocessed messages all vnode message queues in the Riak Search subsystem have received on this node in the last minute"
+   value_threshold = 0
+}
+
   metric {
-    name  = "riak_mem_total"
-    title = "riak_mem_total"
-    value_threshold = 0
-  }
+   name = "riak_riak_search_vnodeq_min"
+   title = "Minimum number of unprocessed messages all vnode message queues in the Riak Search subsystem have received on this node in the last minute"
+   value_threshold = 0
+}
+
   metric {
-    name  = "riak_ring_num_partitions"
-    title = "riak_ring_num_partitions"
-    value_threshold = 0
-  }
+   name = "riak_riak_search_vnodeq_total"
+   title = "Total number of unprocessed messages all vnode message queues in the Riak Search subsystem have received on this node since it was started"
+   value_threshold = 0
+}
+
   metric {
-    name  = "riak_mem_allocated"
-    title = "riak_mem_allocated"
-    value_threshold = 0
-  }
+   name = "riak_riak_search_vnodes_running"
+   title = "Total number of vnodes currently running in the Riak Search subsystem"
+   value_threshold = 0
+}
+
   metric {
-    name  = "riak_node_put_fsm_time_99"
-    title = "99th percentile for riak_kv_put_fsm calls"
-    value_threshold = 0
-  }
+   name = "riak_rings_reconciled_total"
+   title = "Total rings_reconciled"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_sys_smp_support"
+   title = "Boolean value representing whether symmetric multi-processing (SMP) is available"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_sys_threads_enabled"
+   title = "Boolean value representing whether threads are enabled"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_vnode_gets_total"
+   title = "Total number of GETs coordinated by local vnodes"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_vnode_index_deletes_postings_total"
+   title = "Total number of individual secondary index values deleted"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_vnode_index_deletes_total"
+   title = "Total number of local replicas participating in secondary index deletes"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_vnode_index_reads_total"
+   title = "Total number of local replicas participating in secondary index reads"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_vnode_index_writes_postings_total"
+   title = "Total number of individual secondary index values written"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_vnode_puts_total"
+   title = "Total number of PUTS coordinated by local vnodes"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_converge_delay_last"
+   title = "Last observed histogram value in milliseconds describing time taken for the ring to converge after ring changes"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_converge_delay_max"
+   title = "Maximum time in milliseconds describing time taken for the ring to converge after ring changes"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_converge_delay_mean"
+   title = "Mean time in milliseconds describing time taken for the ring to converge after ring changes"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_converge_delay_min"
+   title = "Minimum time in milliseconds describing time taken for the ring to converge after ring changes"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_cpu_avg1"
+   title = "The average number of active processes for the last 1 minute (equivalent to top(1) command\u2019s load average when divided by 256())"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_cpu_avg15"
+   title = "The average number of active processes for the last 15 minutes (equivalent to top(1) command\u2019s load average when divided by 256())"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_cpu_avg5"
+   title = "The average number of active processes for the last 5 minutes (equivalent to top(1) command\u2019s load average when divided by 256())"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_cpu_nprocs"
+   title = "Number of operating system processes"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_executing_mappers"
+   title = "Mean for executing_mappers"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_gossip_received"
+   title = "Number of gossip messages received in the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_handoff_timeouts"
+   title = "Total number of handoff timeouts encountered by this node since it was started"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_index_fsm_active"
+   title = "Number of active Secondary Index FSMs"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_index_fsm_create"
+   title = "Number of Secondary Index query FSMs created in the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_index_fsm_create_error"
+   title = "Number of Secondary Index query FSM creation errors in the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_list_fsm_active"
+   title = "Number of active Keylisting FSMs"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_list_fsm_create"
+   title = "Number of Keylisting FSMs created in the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_list_fsm_create_error"
+   title = "Number of Keylisting FSM creation errors in the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_mem_allocated"
+   title = "Total memory allocated for this node"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_get_fsm_active"
+   title = "Number of active GET FSMs"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_get_fsm_active_60s"
+   title = "Number of GET FSMs active in the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_get_fsm_in_rate"
+   title = "Average number of GET FSMs enqueued by Sidejob"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_get_fsm_objsize_100"
+   title = "100th percentile object size encountered by this node within the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_get_fsm_objsize_95"
+   title = "95th percentile object size encountered by this node within the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_get_fsm_objsize_99"
+   title = "99th percentile object size encountered by this node within the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_get_fsm_objsize_mean"
+   title = "Mean object size encountered by this node within the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_get_fsm_objsize_median"
+   title = "Median object size encountered by this node within the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_get_fsm_out_rate"
+   title = "Average number of GET FSMs dequeued by Sidejob"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_get_fsm_rejected"
+   title = "Number of GET FSMs actively being rejected by Sidejob's overload protection"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_get_fsm_rejected_60s"
+   title = "Number of GET FSMs rejected by Sidejob's overload protection in the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_get_fsm_siblings_100"
+   title = "100th percentile of siblings encountered during all GET operations by this node within the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_get_fsm_siblings_95"
+   title = "95th percentile of siblings encountered during all GET operations by this node within the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_get_fsm_siblings_99"
+   title = "99th percentile of siblings encountered during all GET operations by this node within the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_get_fsm_siblings_mean"
+   title = "Mean number of siblings encountered during all GET operations by this node within the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_get_fsm_siblings_median"
+   title = "Median number of siblings encountered during all GET operations by this node within the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_get_fsm_time_100"
+   title = "100th percentile time between reception of client GET request and subsequent response to client"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_get_fsm_time_95"
+   title = "95th percentile time between reception of client GET request and subsequent response to client"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_get_fsm_time_99"
+   title = "99th percentile time between reception of client GET request and subsequent response to client"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_get_fsm_time_mean"
+   title = "Mean time between reception of client GET request and subsequent response to client"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_get_fsm_time_median"
+   title = "Median time between reception of client GET request and subsequent response to client"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_gets"
+   title = "Number of GETs coordinated by this node, including GETs to non-local vnodes in the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_put_fsm_active"
+   title = "Number of active PUT FSMs"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_put_fsm_active_60s"
+   title = "Number of PUT FSMs active in the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_put_fsm_in_rate"
+   title = "Average number of PUT FSMs enqueued by Sidejob"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_put_fsm_out_rate"
+   title = "Average number of PUT FSMs dequeued by Sidejob"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_put_fsm_rejected"
+   title = "Number of PUT FSMs actively being rejected by Sidejob's overload protection"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_put_fsm_rejected_60s"
+   title = "Number of PUT FSMs rejected by Sidejob's overload protection in the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_put_fsm_time_100"
+   title = "100th percentile time between reception of client PUT request and subsequent response to client"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_put_fsm_time_95"
+   title = "95th percentile time between reception of client PUT request and subsequent response to client"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_put_fsm_time_99"
+   title = "99th percentile time between reception of client PUT request and subsequent response to client"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_put_fsm_time_mean"
+   title = "Mean time between reception of client PUT request and subsequent response to client"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_put_fsm_time_median"
+   title = "Median time between reception of client PUT request and subsequent response to client"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_node_puts"
+   title = "Number of PUTs coordinated by this node, where a PUT is sent to a local vnode in the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_pbc_active"
+   title = "Number of active Protocol Buffers connections"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_pbc_connects"
+   title = "Number of Protocol Buffers connections made in the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_pipeline_active"
+   title = "The number of pipelines active in the last 60 seconds"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_pipeline_create_count"
+   title = "The total number of pipelines created since the node was started"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_pipeline_create_error_count"
+   title = "The total number of pipeline creation errors since the node was started"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_pipeline_create_error_one"
+   title = "The number of pipeline creation errors in the last 60 seconds"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_pipeline_create_one"
+   title = "The number of pipelines created in the last 60 seconds"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_postcommit_fail"
+   title = "Total number of post-commit hook failures"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_precommit_fail"
+   title = "Total number of pre-commit hook failures"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_read_repairs"
+   title = "Number of read repair operations this node has coordinated in the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_read_repairs_primary_notfound_count"
+   title = "Total number of read repair operations performed on primary vnodes due to missing replicas"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_read_repairs_primary_notfound_one"
+   title = "Number of read repair operations performed on primary vnodes in the last minute due to missing replicas"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_read_repairs_primary_outofdate_count"
+   title = "Total number of read repair operations performed on primary vnodes due to stale replicas"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_read_repairs_primary_outofdate_one"
+   title = "Number of read repair operations performed on primary vnodes in the last minute due to stale replicas"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_rebalance_delay_last"
+   title = "Mean for rebalance_delay_last"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_rebalance_delay_max"
+   title = "Mean for rebalance_delay_max"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_rebalance_delay_mean"
+   title = "Mean for rebalance_delay_mean"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_rebalance_delay_min"
+   title = "Mean for rebalance_delay_min"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_rejected_handoffs"
+   title = "Mean for rejected_handoffs"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_riak_core_stat_ts"
+   title = "Mean for riak_core_stat_ts"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_riak_kv_stat_ts"
+   title = "The last time Riak KV stats were generated."
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_riak_kv_vnodeq_max"
+   title = "Mean for riak_kv_vnodeq_max"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_riak_kv_vnodeq_mean"
+   title = "Mean for riak_kv_vnodeq_mean"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_riak_kv_vnodeq_median"
+   title = "Mean for riak_kv_vnodeq_median"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_riak_kv_vnodeq_min"
+   title = "Mean for riak_kv_vnodeq_min"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_riak_kv_vnodes_running"
+   title = "Mean for riak_kv_vnodes_running"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_riak_pipe_stat_ts"
+   title = "The last time Riak Pipe stats were generated."
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_riak_pipe_vnodeq_max"
+   title = "Mean for riak_pipe_vnodeq_max"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_riak_pipe_vnodeq_mean"
+   title = "Mean for riak_pipe_vnodeq_mean"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_riak_pipe_vnodeq_median"
+   title = "Mean for riak_pipe_vnodeq_median"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_riak_pipe_vnodeq_min"
+   title = "Mean for riak_pipe_vnodeq_min"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_riak_pipe_vnodes_running"
+   title = "Mean for riak_pipe_vnodes_running"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_ring_creation_size"
+   title = "Ring size this cluster was created with"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_ring_num_partitions"
+   title = "The number of partitions in the ring"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_rings_reconciled"
+   title = "Mean for rings_reconciled"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_sys_global_heaps_size"
+   title = "Current size of the shared global heap"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_sys_logical_processors"
+   title = "Number of logical processors available on the system"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_vnode_index_deletes_postings"
+   title = "Number of individual secondary index values deleted in the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_vnode_index_reads"
+   title = "Number of local replicas participating in secondary index reads in the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_vnode_index_writes"
+   title = "Number of local replicas participating in secondary index writes in the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_vnode_index_writes_postings"
+   title = "Number of individual secondary index values written in the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_vnode_puts"
+   title = "Number of PUT operations coordinated by local vnodes on this node in the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_sys_process_count"
+   title = "Number of processes currently running in the Erlang VM"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_sys_thread_pool_size"
+   title = "Number of threads in the asynchronous thread pool"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_sys_wordsize"
+   title = "Size of Erlang term words in bytes as an integer, for examples, on 32-bit architectures 4 is returned and on 64-bit architectures 8 is returned"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_vnode_gets"
+   title = "Number of GET operations coordinated by local vnodes on this node in the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_vnode_index_deletes"
+   title = "Number of local replicas participating in secondary index deletes in the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_vnode_index_refreshes"
+   title = "Number of secondary indexes refreshed on this node during secondary index anti-entropy in the last minute"
+   value_threshold = 0
+}
+
+  metric {
+   name = "riak_coord_redirs_total"
+   title = "Total number of requests this node has redirected to other nodes for coordination"
+   value_threshold = 0
+}
 }

--- a/gmond/python_modules/conf.d/vm_stats.pyconf
+++ b/gmond/python_modules/conf.d/vm_stats.pyconf
@@ -11,26 +11,28 @@ collection_group {
 
   metric {
       name = "vm_vmeff"
-      title = "VM Efficiency"
       value_threshold = 1.0
   }
 
   metric {
       name = "vm_pgmajfault"
-      title = "Major page fault"
       value_threshold = 1.0
   }
 
   metric {
       name = "vm_pgpgin"
-      title = "Pages in from disk"
       value_threshold = 1.0
   }
 
   metric {
       name = "vm_pgpgout"
-      title = "Pages out to disk"
       value_threshold = 1.0
   }
+
+  metric {
+      name = "vm_nr_written"
+      value_threshold = 1.0
+  }
+
 
 }

--- a/gmond/python_modules/cpu/cpu_stats.py
+++ b/gmond/python_modules/cpu/cpu_stats.py
@@ -6,27 +6,26 @@ import time
 import copy
 
 METRICS = {
-    'time' : 0,
-    'data' : {}
+    'time': 0,
+    'data': {}
 }
 
 # Got these from /proc/softirqs
 softirq_pos = {
-  'hi' : 1,
-  'timer' : 2,
-  'nettx' : 3,
-  'netrx' : 4,
-  'block' : 5,
-  'blockiopoll' : 6,
-  'tasklet' : 7,
-  'sched' : 8,
-  'hrtimer' : 9,
-  'rcu' : 10
+  'hi': 1,
+  'timer': 2,
+  'nettx': 3,
+  'netrx': 4,
+  'block': 5,
+  'blockiopoll': 6,
+  'tasklet': 7,
+  'sched': 8,
+  'hrtimer': 9,
+  'rcu': 10
 }
 
 LAST_METRICS = copy.deepcopy(METRICS)
 METRICS_CACHE_MAX = 5
-
 
 
 stat_file = "/proc/stat"
@@ -34,6 +33,8 @@ stat_file = "/proc/stat"
 ###############################################################################
 #
 ###############################################################################
+
+
 def get_metrics():
     """Return all metrics"""
 
@@ -41,11 +42,11 @@ def get_metrics():
 
     if (time.time() - METRICS['time']) > METRICS_CACHE_MAX:
 
-	try:
-	    file = open(stat_file, 'r')
-    
-	except IOError:
-	    return 0
+        try:
+            file = open(stat_file, 'r')
+
+        except IOError:
+            return 0
 
         # convert to dict
         metrics = {}
@@ -68,9 +69,9 @@ def get_value(name):
 
     metrics = get_metrics()[0]
 
-    NAME_PREFIX="cpu_"
+    NAME_PREFIX = "cpu_"
 
-    name = name.replace(NAME_PREFIX,"") # remove prefix from name
+    name = name.replace(NAME_PREFIX, "")  # remove prefix from name
 
     try:
         result = metrics['data'][name][0]
@@ -86,55 +87,57 @@ def get_delta(name):
     # get metrics
     [curr_metrics, last_metrics] = get_metrics()
 
-    NAME_PREFIX="cpu_"
+    NAME_PREFIX = "cpu_"
 
-    name = name.replace(NAME_PREFIX,"") # remove prefix from name
+    name = name.replace(NAME_PREFIX, "")  # remove prefix from name
 
     if name == "procs_created":
-      name = "processes"
+        name = "processes"
 
     try:
-      delta = (float(curr_metrics['data'][name][0]) - float(last_metrics['data'][name][0])) /(curr_metrics['time'] - last_metrics['time'])
-      if delta < 0:
-	print name + " is less 0"
-	delta = 0
+        delta = (float(curr_metrics['data'][name][0]) - float(last_metrics['data'][name][0])) / (curr_metrics['time'] - last_metrics['time'])
+        if delta < 0:
+            print name + " is less 0"
+            delta = 0
     except KeyError:
-      delta = 0.0      
+        delta = 0.0
 
     return delta
 
 ##############################################################################
 # SoftIRQ has multiple values which are defined in a dictionary at the top
 ##############################################################################
+
+
 def get_softirq_delta(name):
     """Return change over time for the requested metric"""
 
     # get metrics
     [curr_metrics, last_metrics] = get_metrics()
 
-    NAME_PREFIX="softirq_"
+    NAME_PREFIX = "softirq_"
 
-    name = name[len(NAME_PREFIX):] # remove prefix from name
+    name = name[len(NAME_PREFIX):]  # remove prefix from name
 
     index = softirq_pos[name]
 
     try:
-      delta = (float(curr_metrics['data']['softirq'][index]) - float(last_metrics['data']['softirq'][index])) /(curr_metrics['time'] - last_metrics['time'])
-      if delta < 0:
-	print name + " is less 0"
-	delta = 0
+        delta = (float(curr_metrics['data']['softirq'][index]) - float(last_metrics['data']['softirq'][index])) / (curr_metrics['time'] - last_metrics['time'])
+        if delta < 0:
+            print name + " is less 0"
+            delta = 0
     except KeyError:
-      delta = 0.0      
+        delta = 0.0
 
     return delta
 
 
-
 def create_desc(skel, prop):
     d = skel.copy()
-    for k,v in prop.iteritems():
+    for k, v in prop.iteritems():
         d[k] = v
     return d
+
 
 def metric_init(params):
     global descriptors, metric_map, Desc_Skel
@@ -149,7 +152,7 @@ def metric_init(params):
         'value_type'  : 'float',
         'format'      : '%.0f',
         'units'       : 'XXX',
-        'slope'       : 'both', # zero|positive|negative|both
+        'slope'       : 'both',  # zero|positive|negative|both
         'description' : '',
         'groups'      : 'cpu',
         }
@@ -255,19 +258,20 @@ def metric_init(params):
                 "call_back"   : get_softirq_delta
                 }))
 
-
     # We need a metric_map that maps metric_name to the index in /proc/meminfo
     metric_map = {}
-    
+
     for d in descriptors:
-	metric_name = d['name']
-        metric_map[metric_name] = { "name": d['orig_name'], "units": d['units'] }
-        
+        metric_name = d['name']
+        metric_map[metric_name] = {"name": d['orig_name'], "units": d['units']}
+
     return descriptors
+
 
 def metric_cleanup():
     '''Clean up the metric module.'''
     pass
+
 
 #This code is for debugging and unit testing
 if __name__ == '__main__':
@@ -275,6 +279,6 @@ if __name__ == '__main__':
     while True:
         for d in descriptors:
             v = d['call_back'](d['name'])
-            print '%s = %s' % (d['name'],  v)
+            print '%s = %s' % (d['name'], v)
         print 'Sleeping 15 seconds'
         time.sleep(5)

--- a/gmond/python_modules/db/DBUtil.py
+++ b/gmond/python_modules/db/DBUtil.py
@@ -73,6 +73,7 @@ def is_hex(s):
     except ValueError:
         return False
 
+
 def longish(x):
         if len(x):
                 try:
@@ -87,196 +88,196 @@ def longish(x):
         else:
                 raise ValueError
 
+
 def hexlongish(x):
-	if len(x):
-		try:
-			return long(str(x), 16)
-		except ValueError:
-			return longish(x[:-1])
-	else:
-		raise ValueError
+        if len(x):
+                try:
+                        return long(str(x), 16)
+                except ValueError:
+                        return longish(x[:-1])
+        else:
+                raise ValueError
 
 def parse_innodb_status(innodb_status_raw, innodb_version="1.0"):
-	def sumof(status):
-		def new(*idxs):
-			return sum(map(lambda x: longish(status[x]), idxs))
-		return new
+        def sumof(status):
+                def new(*idxs):
+                        return sum(map(lambda x: longish(status[x]), idxs))
+                return new
 
-	innodb_status = defaultdict(int)
-	innodb_status['active_transactions']
-	individual_buffer_pool_info = False
-	
-	for line in innodb_status_raw:
-		istatus = line.split()
+        innodb_status = defaultdict(int)
+        innodb_status['active_transactions']
+        individual_buffer_pool_info = False
 
-		isum = sumof(istatus)
+        for line in innodb_status_raw:
+                istatus = line.split()
 
-		# SEMAPHORES
-		if "Mutex spin waits" in line:
-			innodb_status['spin_waits'] += longish(istatus[3])
-			innodb_status['spin_rounds'] += longish(istatus[5])
-			innodb_status['os_waits'] += longish(istatus[8])
+                isum = sumof(istatus)
 
-		elif "RW-shared spins" in line:
-			if innodb_version == 1.0:
-				innodb_status['spin_waits'] += isum(2,8)
-				innodb_status['os_waits'] += isum(5,11)
-			elif innodb_version >= 5.5:
-				innodb_status['spin_waits'] += longish(istatus[2])
-				innodb_status['os_waits'] += longish(istatus[7])
+                # SEMAPHORES
+                if "Mutex spin waits" in line:
+                        innodb_status['spin_waits'] += longish(istatus[3])
+                        innodb_status['spin_rounds'] += longish(istatus[5])
+                        innodb_status['os_waits'] += longish(istatus[8])
 
-		elif "RW-excl spins" in line and innodb_version >= 5.5:
-			innodb_status['spin_waits'] += longish(istatus[2])
-			innodb_status['os_waits'] += longish(istatus[7])
+                elif "RW-shared spins" in line:
+                        if innodb_version == 1.0:
+                                innodb_status['spin_waits'] += isum(2, 8)
+                                innodb_status['os_waits'] += isum(5, 11)
+                        elif innodb_version >= 5.5:
+                                innodb_status['spin_waits'] += longish(istatus[2])
+                                innodb_status['os_waits'] += longish(istatus[7])
 
-		# TRANSACTIONS
-		elif "Trx id counter" in line:
-			if innodb_version >= 5.6:
-				innodb_status['transactions'] += longish(istatus[3])
-			elif innodb_version == 5.5:
-				innodb_status['transactions'] += hexlongish(istatus[3])
-			else:
-				innodb_status['transactions'] += isum(3,4)
+                elif "RW-excl spins" in line and innodb_version >= 5.5:
+                        innodb_status['spin_waits'] += longish(istatus[2])
+                        innodb_status['os_waits'] += longish(istatus[7])
 
-		elif "Purge done for trx" in line:
-			if innodb_version >= 5.6:
-				innodb_status['transactions_purged'] += longish(istatus[6])
-			elif innodb_version == 5.5:
-				innodb_status['transactions_purged'] += hexlongish(istatus[6])
-			else:
-				innodb_status['transactions_purged'] += isum(6,7)
+                # TRANSACTIONS
+                elif "Trx id counter" in line:
+                        if innodb_version >= 5.6:
+                                innodb_status['transactions'] += longish(istatus[3])
+                        elif innodb_version == 5.5:
+                                innodb_status['transactions'] += hexlongish(istatus[3])
+                        else:
+                                innodb_status['transactions'] += isum(3, 4)
 
-		elif "History list length" in line:
-			innodb_status['history_list'] = longish(istatus[3])
+                elif "Purge done for trx" in line:
+                        if innodb_version >= 5.6:
+                                innodb_status['transactions_purged'] += longish(istatus[6])
+                        elif innodb_version == 5.5:
+                                innodb_status['transactions_purged'] += hexlongish(istatus[6])
+                        else:
+                                innodb_status['transactions_purged'] += isum(6, 7)
 
-		elif "---TRANSACTION" in line and innodb_status['transactions']:
-			innodb_status['current_transactions'] += 1
-			if "ACTIVE" in line:
-				innodb_status['active_transactions'] += 1
+                elif "History list length" in line:
+                        innodb_status['history_list'] = longish(istatus[3])
 
-		elif "LOCK WAIT" in line and innodb_status['transactions']:
-			innodb_status['locked_transactions'] += 1
+                elif "---TRANSACTION" in line and innodb_status['transactions']:
+                        innodb_status['current_transactions'] += 1
+                        if "ACTIVE" in line:
+                                innodb_status['active_transactions'] += 1
 
-		elif 'read views open inside' in line:
-			innodb_status['read_views'] = longish(istatus[0])
+                elif "LOCK WAIT" in line and innodb_status['transactions']:
+                        innodb_status['locked_transactions'] += 1
 
-		# FILE I/O
-		elif 'OS file reads' in line:
-			innodb_status['data_reads'] = longish(istatus[0])
-			innodb_status['data_writes'] = longish(istatus[4])
-			innodb_status['data_fsyncs'] = longish(istatus[8])
+                elif 'read views open inside' in line:
+                        innodb_status['read_views'] = longish(istatus[0])
 
-		elif 'Pending normal aio' in line:
-			innodb_status['pending_normal_aio_reads'] = longish(istatus[4])
-			innodb_status['pending_normal_aio_writes'] = longish(istatus[7])
+                # FILE I/O
+                elif 'OS file reads' in line:
+                        innodb_status['data_reads'] = longish(istatus[0])
+                        innodb_status['data_writes'] = longish(istatus[4])
+                        innodb_status['data_fsyncs'] = longish(istatus[8])
 
-		elif 'ibuf aio reads' in line:
-			innodb_status['pending_ibuf_aio_reads'] = longish(istatus[3])
-			innodb_status['pending_aio_log_ios'] = longish(istatus[6])
-			innodb_status['pending_aio_sync_ios'] = longish(istatus[9])
+                elif 'Pending normal aio' in line:
+                        innodb_status['pending_normal_aio_reads'] = longish(istatus[4])
+                        innodb_status['pending_normal_aio_writes'] = longish(istatus[7])
 
-		elif 'Pending flushes (fsync)' in line:
-			innodb_status['pending_log_flushes'] = longish(istatus[4])
-			innodb_status['pending_buffer_pool_flushes'] = longish(istatus[7])
+                elif 'ibuf aio reads' in line:
+                        innodb_status['pending_ibuf_aio_reads'] = longish(istatus[3])
+                        innodb_status['pending_aio_log_ios'] = longish(istatus[6])
+                        innodb_status['pending_aio_sync_ios'] = longish(istatus[9])
 
-		# INSERT BUFFER AND ADAPTIVE HASH INDEX
-		elif 'merged recs' in line and innodb_version == 1.0:
-			innodb_status['ibuf_inserts'] = longish(istatus[0])
-			innodb_status['ibuf_merged'] = longish(istatus[2])
-			innodb_status['ibuf_merges'] = longish(istatus[5])
+                elif 'Pending flushes (fsync)' in line:
+                        innodb_status['pending_log_flushes'] = longish(istatus[4])
+                        innodb_status['pending_buffer_pool_flushes'] = longish(istatus[7])
 
-		elif 'Ibuf: size' in line and innodb_version >= 5.5:
-			innodb_status['ibuf_merges'] = longish(istatus[10])
+                # INSERT BUFFER AND ADAPTIVE HASH INDEX
+                elif 'merged recs' in line and innodb_version == 1.0:
+                        innodb_status['ibuf_inserts'] = longish(istatus[0])
+                        innodb_status['ibuf_merged'] = longish(istatus[2])
+                        innodb_status['ibuf_merges'] = longish(istatus[5])
 
-		elif 'merged operations' in line and innodb_version >= 5.5:
-			in_merged = 1
+                elif 'Ibuf: size' in line and innodb_version >= 5.5:
+                        innodb_status['ibuf_merges'] = longish(istatus[10])
 
-		elif 'delete mark' in line and 'in_merged' in vars() and innodb_version >= 5.5:
-			innodb_status['ibuf_inserts'] = longish(istatus[1])
-			innodb_status['ibuf_merged'] = 0
-			del in_merged
+                elif 'merged operations' in line and innodb_version >= 5.5:
+                        in_merged = 1
 
-		# LOG
-		elif "log i/o's done" in line:
-			innodb_status['log_writes'] = longish(istatus[0])
+                elif 'delete mark' in line and 'in_merged' in vars() and innodb_version >= 5.5:
+                        innodb_status['ibuf_inserts'] = longish(istatus[1])
+                        innodb_status['ibuf_merged'] = 0
+                        del in_merged
 
-		elif "pending log writes" in line:
-			innodb_status['pending_log_writes'] = longish(istatus[0])
-			innodb_status['pending_chkp_writes'] = longish(istatus[4])
-		
-		elif "Log sequence number" in line:
-			if innodb_version >= 5.5:
-				innodb_status['log_bytes_written'] = longish(istatus[3])
-			else:
-				innodb_status['log_bytes_written'] = isum(3,4)
-		
-		elif "Log flushed up to" in line:
-			if innodb_version >= 5.5:
-				innodb_status['log_bytes_flushed'] = longish(istatus[4])
-			else:
-				innodb_status['log_bytes_flushed'] = isum(4,5)
+                # LOG
+                elif "log i/o's done" in line:
+                        innodb_status['log_writes'] = longish(istatus[0])
 
-		# BUFFER POOL AND MEMORY
-		elif "INDIVIDUAL BUFFER POOL INFO" in line:
-			# individual pools section.  We only want to record the totals 
-			# rather than each individual pool clobbering the totals
-			individual_buffer_pool_info = True
+                elif "pending log writes" in line:
+                        innodb_status['pending_log_writes'] = longish(istatus[0])
+                        innodb_status['pending_chkp_writes'] = longish(istatus[4])
 
-		elif "Buffer pool size, bytes" in line and not individual_buffer_pool_info:
-			innodb_status['buffer_pool_pages_bytes'] = longish(istatus[4])
+                elif "Log sequence number" in line:
+                        if innodb_version >= 5.5:
+                                innodb_status['log_bytes_written'] = longish(istatus[3])
+                        else:
+                                innodb_status['log_bytes_written'] = isum(3, 4)
 
-		elif "Buffer pool size" in line and not individual_buffer_pool_info:
-			innodb_status['buffer_pool_pages_total'] = longish(istatus[3])
-		
-		elif "Free buffers" in line and not individual_buffer_pool_info:
-			innodb_status['buffer_pool_pages_free'] = longish(istatus[2])
-		
-		elif "Database pages" in line and not individual_buffer_pool_info:
-			innodb_status['buffer_pool_pages_data'] = longish(istatus[2])
-		
-		elif "Modified db pages" in line and not individual_buffer_pool_info:
-			innodb_status['buffer_pool_pages_dirty'] = longish(istatus[3])
-		
-		elif "Pages read" in line and "ahead" not in line and not individual_buffer_pool_info:
-				innodb_status['pages_read'] = longish(istatus[2])
-				innodb_status['pages_created'] = longish(istatus[4])
-				innodb_status['pages_written'] = longish(istatus[6])
+                elif "Log flushed up to" in line:
+                        if innodb_version >= 5.5:
+                                innodb_status['log_bytes_flushed'] = longish(istatus[4])
+                        else:
+                                innodb_status['log_bytes_flushed'] = isum(4, 5)
 
-		# ROW OPERATIONS
-		elif 'Number of rows inserted' in line:
-			innodb_status['rows_inserted'] = longish(istatus[4])
-			innodb_status['rows_updated'] = longish(istatus[6])
-			innodb_status['rows_deleted'] = longish(istatus[8])
-			innodb_status['rows_read'] = longish(istatus[10])
-		
-		elif "queries inside InnoDB" in line:
-			innodb_status['queries_inside'] = longish(istatus[0])
-			innodb_status['queries_queued'] = longish(istatus[4])
+                # BUFFER POOL AND MEMORY
+                elif "INDIVIDUAL BUFFER POOL INFO" in line:
+                        # individual pools section.  We only want to record the totals
+                        # rather than each individual pool clobbering the totals
+                        individual_buffer_pool_info = True
 
-	# Some more stats
-	innodb_status['transactions_unpurged'] = innodb_status['transactions'] - innodb_status['transactions_purged']
-	innodb_status['log_bytes_unflushed'] = innodb_status['log_bytes_written'] - innodb_status['log_bytes_flushed']
+                elif "Buffer pool size, bytes" in line and not individual_buffer_pool_info:
+                        innodb_status['buffer_pool_pages_bytes'] = longish(istatus[4])
 
-	return innodb_status
-	
+                elif "Buffer pool size" in line and not individual_buffer_pool_info:
+                        innodb_status['buffer_pool_pages_total'] = longish(istatus[3])
+
+                elif "Free buffers" in line and not individual_buffer_pool_info:
+                        innodb_status['buffer_pool_pages_free'] = longish(istatus[2])
+
+                elif "Database pages" in line and not individual_buffer_pool_info:
+                        innodb_status['buffer_pool_pages_data'] = longish(istatus[2])
+
+                elif "Modified db pages" in line and not individual_buffer_pool_info:
+                        innodb_status['buffer_pool_pages_dirty'] = longish(istatus[3])
+
+                elif "Pages read" in line and "ahead" not in line and not individual_buffer_pool_info:
+                                innodb_status['pages_read'] = longish(istatus[2])
+                                innodb_status['pages_created'] = longish(istatus[4])
+                                innodb_status['pages_written'] = longish(istatus[6])
+
+                # ROW OPERATIONS
+                elif 'Number of rows inserted' in line:
+                        innodb_status['rows_inserted'] = longish(istatus[4])
+                        innodb_status['rows_updated'] = longish(istatus[6])
+                        innodb_status['rows_deleted'] = longish(istatus[8])
+                        innodb_status['rows_read'] = longish(istatus[10])
+
+                elif "queries inside InnoDB" in line:
+                        innodb_status['queries_inside'] = longish(istatus[0])
+                        innodb_status['queries_queued'] = longish(istatus[4])
+
+        # Some more stats
+        innodb_status['transactions_unpurged'] = innodb_status['transactions'] - innodb_status['transactions_purged']
+        innodb_status['log_bytes_unflushed'] = innodb_status['log_bytes_written'] - innodb_status['log_bytes_flushed']
+
+        return innodb_status
+
 if __name__ == '__main__':
-	from optparse import OptionParser
+        from optparse import OptionParser
 
-	parser = OptionParser()
-	parser.add_option("-H", "--Host", dest="host", help="Host running mysql", default="localhost")
-	parser.add_option("-u", "--user", dest="user", help="user to connect as", default="")
-	parser.add_option("-p", "--password", dest="passwd", help="password", default="")
-	(options, args) = parser.parse_args()
+        parser = OptionParser()
+        parser.add_option("-H", "--Host", dest="host", help="Host running mysql", default="localhost")
+        parser.add_option("-u", "--user", dest="user", help="user to connect as", default="")
+        parser.add_option("-p", "--password", dest="passwd", help="password", default="")
+        (options, args) = parser.parse_args()
 
-	try:
-		conn = MySQLdb.connect(user=options.user, host=options.host, passwd=options.passwd)
+        try:
+                conn = MySQLdb.connect(user=options.user, host=options.host, passwd=options.passwd)
 
-		cursor = conn.cursor(MySQLdb.cursors.Cursor)
-		cursor.execute("SHOW /*!50000 ENGINE*/ INNODB STATUS")
-		innodb_status = parse_innodb_status(cursor.fetchone()[0].split('\n'))
-		cursor.close()
+                cursor = conn.cursor(MySQLdb.cursors.Cursor)
+                cursor.execute("SHOW /*!50000 ENGINE*/ INNODB STATUS")
+                innodb_status = parse_innodb_status(cursor.fetchone()[0].split('\n'))
+                cursor.close()
 
-		conn.close()
-	except MySQLdb.OperationalError, (errno, errmsg):
-		raise
-
+                conn.close()
+        except MySQLdb.OperationalError, (errno, errmsg):
+                raise

--- a/gmond/python_modules/db/mysql.py
+++ b/gmond/python_modules/db/mysql.py
@@ -61,1117 +61,1118 @@ delta_per_second = False
 
 REPORT_INNODB = True
 REPORT_MASTER = True
-REPORT_SLAVE  = True
+REPORT_SLAVE = True
 
 MAX_UPDATE_TIME = 15
 
+
 def update_stats(get_innodb=True, get_master=True, get_slave=True):
-	"""
+    """
 
-	"""
-	logging.debug('updating stats')
-	global last_update
-	global mysql_stats, mysql_stats_last
+    """
+    logging.debug('updating stats')
+    global last_update
+    global mysql_stats, mysql_stats_last
 
-	cur_time = time.time()
-	time_delta = cur_time - last_update
-	if time_delta <= 0:
-		#we went backward in time.
-		logging.debug(" system clock set backwards, probably ntp")
+    cur_time = time.time()
+    time_delta = cur_time - last_update
+    if time_delta <= 0:
+        #we went backward in time.
+        logging.debug(" system clock set backwards, probably ntp")
 
-	if cur_time - last_update < MAX_UPDATE_TIME:
-		logging.debug(' wait ' + str(int(MAX_UPDATE_TIME - (cur_time - last_update))) + ' seconds')
-		return True
-	else:
-		last_update = cur_time
+    if cur_time - last_update < MAX_UPDATE_TIME:
+        logging.debug(' wait ' + str(int(MAX_UPDATE_TIME - (cur_time - last_update))) + ' seconds')
+        return True
+    else:
+        last_update = cur_time
 
-	logging.debug('refreshing stats')
-	mysql_stats = {}
+    logging.debug('refreshing stats')
+    mysql_stats = {}
 
-	# Get info from DB
-	try:
-		conn = MySQLdb.connect(**mysql_conn_opts)
+    # Get info from DB
+    try:
+        conn = MySQLdb.connect(**mysql_conn_opts)
 
-		cursor = conn.cursor(MySQLdb.cursors.DictCursor)
-		cursor.execute("SELECT GET_LOCK('gmetric-mysql', 0) as ok")
-		lock_stat = cursor.fetchone()
-		cursor.close()
+        cursor = conn.cursor(MySQLdb.cursors.DictCursor)
+        cursor.execute("SELECT GET_LOCK('gmetric-mysql', 0) as ok")
+        lock_stat = cursor.fetchone()
+        cursor.close()
 
-		if lock_stat['ok'] == 0:
-			return False
+        if lock_stat['ok'] == 0:
+            return False
 
-		cursor = conn.cursor(MySQLdb.cursors.Cursor)
-		cursor.execute("SHOW VARIABLES")
-		#variables = dict(((k.lower(), v) for (k,v) in cursor))
-		variables = {}
-		for (k,v) in cursor:
-			variables[k.lower()] = v
-		cursor.close()
+        cursor = conn.cursor(MySQLdb.cursors.Cursor)
+        cursor.execute("SHOW VARIABLES")
+        #variables = dict(((k.lower(), v) for (k,v) in cursor))
+        variables = {}
+        for (k, v) in cursor:
+            variables[k.lower()] = v
+        cursor.close()
 
-		cursor = conn.cursor(MySQLdb.cursors.Cursor)
-		cursor.execute("SHOW /*!50002 GLOBAL */ STATUS")
-		#global_status = dict(((k.lower(), v) for (k,v) in cursor))
-		global_status = {}
-		for (k,v) in cursor:
-			global_status[k.lower()] = v
-		cursor.close()
-		
-		cursor = conn.cursor(MySQLdb.cursors.Cursor)
-		cursor.execute("SELECT PLUGIN_STATUS, PLUGIN_VERSION FROM `information_schema`.Plugins WHERE PLUGIN_NAME LIKE '%innodb%' AND PLUGIN_TYPE LIKE 'STORAGE ENGINE';")
-		
-		have_innodb = False
-		innodb_version = 1.0
-		row = cursor.fetchone()
-		
-		if row[0] == "ACTIVE":
-			have_innodb = True
-			innodb_version = row[1]
-		cursor.close()
+        cursor = conn.cursor(MySQLdb.cursors.Cursor)
+        cursor.execute("SHOW /*!50002 GLOBAL */ STATUS")
+        #global_status = dict(((k.lower(), v) for (k,v) in cursor))
+        global_status = {}
+        for (k, v) in cursor:
+            global_status[k.lower()] = v
+        cursor.close()
 
-		# try not to fail ?
-		get_innodb = get_innodb and have_innodb
-		get_master = get_master and variables['log_bin'].lower() == 'on'
+        cursor = conn.cursor(MySQLdb.cursors.Cursor)
+        cursor.execute("SELECT PLUGIN_STATUS, PLUGIN_VERSION FROM `information_schema`.Plugins WHERE PLUGIN_NAME LIKE '%innodb%' AND PLUGIN_TYPE LIKE 'STORAGE ENGINE';")
 
-		innodb_status = defaultdict(int)
-		if get_innodb:
-			cursor = conn.cursor(MySQLdb.cursors.Cursor)
-			cursor.execute("SHOW /*!50000 ENGINE*/ INNODB STATUS")
-			innodb_status = parse_innodb_status(cursor.fetchone()[2].split('\n'), innodb_version)
-			cursor.close()
-			logging.debug('innodb_status: ' + str(innodb_status))
+        have_innodb = False
+        innodb_version = 1.0
+        row = cursor.fetchone()
 
-		master_logs = tuple
-		if get_master:
-			cursor = conn.cursor(MySQLdb.cursors.Cursor)
-			cursor.execute("SHOW MASTER LOGS")
-			master_logs = cursor.fetchall()
-			cursor.close()
+        if row[0] == "ACTIVE":
+            have_innodb = True
+            innodb_version = row[1]
+        cursor.close()
 
-		slave_status = {}
-		if get_slave:
-			cursor = conn.cursor(MySQLdb.cursors.DictCursor)
-			cursor.execute("SHOW SLAVE STATUS")
-			res = cursor.fetchone()
-			if res:
-				for (k,v) in res.items():
-					slave_status[k.lower()] = v
-			else:
-				get_slave = False
-			cursor.close()
+        # try not to fail ?
+        get_innodb = get_innodb and have_innodb
+        get_master = get_master and variables['log_bin'].lower() == 'on'
 
-		cursor = conn.cursor(MySQLdb.cursors.DictCursor)
-		cursor.execute("SELECT RELEASE_LOCK('gmetric-mysql') as ok")
-		cursor.close()
+        innodb_status = defaultdict(int)
+        if get_innodb:
+            cursor = conn.cursor(MySQLdb.cursors.Cursor)
+            cursor.execute("SHOW /*!50000 ENGINE*/ INNODB STATUS")
+            innodb_status = parse_innodb_status(cursor.fetchone()[2].split('\n'), innodb_version)
+            cursor.close()
+            logging.debug('innodb_status: ' + str(innodb_status))
 
-		conn.close()
-	except MySQLdb.OperationalError, (errno, errmsg):
-		logging.error('error updating stats')
-		logging.error(errmsg)
-		return False
+        master_logs = tuple
+        if get_master:
+            cursor = conn.cursor(MySQLdb.cursors.Cursor)
+            cursor.execute("SHOW MASTER LOGS")
+            master_logs = cursor.fetchall()
+            cursor.close()
 
-	# process variables
-	# http://dev.mysql.com/doc/refman/5.0/en/server-system-variables.html
-	mysql_stats['version'] = variables['version']
-	mysql_stats['max_connections'] = variables['max_connections']
-	mysql_stats['query_cache_size'] = variables['query_cache_size']
+        slave_status = {}
+        if get_slave:
+            cursor = conn.cursor(MySQLdb.cursors.DictCursor)
+            cursor.execute("SHOW SLAVE STATUS")
+            res = cursor.fetchone()
+            if res:
+                for (k,v) in res.items():
+                    slave_status[k.lower()] = v
+            else:
+                get_slave = False
+            cursor.close()
 
-	# process global status
-	# http://dev.mysql.com/doc/refman/5.0/en/server-status-variables.html
-	interesting_global_status_vars = (
-		'aborted_clients',
-		'aborted_connects',
-		'binlog_cache_disk_use',
-		'binlog_cache_use',
-		'bytes_received',
-		'bytes_sent',
-		'com_delete',
-		'com_delete_multi',
-		'com_insert',
-		'com_insert_select',
-		'com_load',
-		'com_replace',
-		'com_replace_select',
-		'com_select',
-		'com_update',
-		'com_update_multi',
-		'connections',
-		'created_tmp_disk_tables',
-		'created_tmp_files',
-		'created_tmp_tables',
-		'key_reads',
-		'key_read_requests',
-		'key_writes',
-		'key_write_requests',
-		'max_used_connections',
-		'open_files',
-		'open_tables',
-		'opened_tables',
-		'qcache_free_blocks',
-		'qcache_free_memory',
-		'qcache_hits',
-		'qcache_inserts',
-		'qcache_lowmem_prunes',
-		'qcache_not_cached',
-		'qcache_queries_in_cache',
-		'qcache_total_blocks',
-		'questions',
-		'select_full_join',
-		'select_full_range_join',
-		'select_range',
-		'select_range_check',
-		'select_scan',
-		'slave_open_temp_tables',
-		'slave_retried_transactions',
-		'slow_launch_threads',
-		'slow_queries',
-		'sort_range',
-		'sort_rows',
-		'sort_scan',
-		'table_locks_immediate',
-		'table_locks_waited',
-		'threads_cached',
-		'threads_connected',
-		'threads_created',
-		'threads_running',
-		'uptime',
-	)
+        cursor = conn.cursor(MySQLdb.cursors.DictCursor)
+        cursor.execute("SELECT RELEASE_LOCK('gmetric-mysql') as ok")
+        cursor.close()
 
-	non_delta = (
-		'max_used_connections',
-		'open_files',
-		'open_tables',
-		'qcache_free_blocks',
-		'qcache_free_memory',
-		'qcache_total_blocks',
-		'slave_open_temp_tables',
-		'threads_cached',
-		'threads_connected',
-		'threads_running',
-		'uptime'
-	)
+        conn.close()
+    except MySQLdb.OperationalError, (errno, errmsg):
+        logging.error('error updating stats')
+        logging.error(errmsg)
+        return False
 
-	# don't put all of global_status in mysql_stats b/c it's so big
-	for key in interesting_global_status_vars:
-		if key in non_delta:
-			mysql_stats[key] = global_status[key]
-		else:
-			# Calculate deltas for counters
-			if time_delta <= 0:
-				#systemclock was set backwards, nog updating values.. to smooth over the graphs
-				pass
-			elif key in mysql_stats_last:
-				if delta_per_second:
-					mysql_stats[key] = (int(global_status[key]) - int(mysql_stats_last[key])) / time_delta
-				else:
-					mysql_stats[key] = int(global_status[key]) - int(mysql_stats_last[key])
-			else:
-				mysql_stats[key] = float(0)
+    # process variables
+    # http://dev.mysql.com/doc/refman/5.0/en/server-system-variables.html
+    mysql_stats['version'] = variables['version']
+    mysql_stats['max_connections'] = variables['max_connections']
+    mysql_stats['query_cache_size'] = variables['query_cache_size']
 
-			mysql_stats_last[key] = global_status[key]
+    # process global status
+    # http://dev.mysql.com/doc/refman/5.0/en/server-status-variables.html
+    interesting_global_status_vars = (
+        'aborted_clients',
+        'aborted_connects',
+        'binlog_cache_disk_use',
+        'binlog_cache_use',
+        'bytes_received',
+        'bytes_sent',
+        'com_delete',
+        'com_delete_multi',
+        'com_insert',
+        'com_insert_select',
+        'com_load',
+        'com_replace',
+        'com_replace_select',
+        'com_select',
+        'com_update',
+        'com_update_multi',
+        'connections',
+        'created_tmp_disk_tables',
+        'created_tmp_files',
+        'created_tmp_tables',
+        'key_reads',
+        'key_read_requests',
+        'key_writes',
+        'key_write_requests',
+        'max_used_connections',
+        'open_files',
+        'open_tables',
+        'opened_tables',
+        'qcache_free_blocks',
+        'qcache_free_memory',
+        'qcache_hits',
+        'qcache_inserts',
+        'qcache_lowmem_prunes',
+        'qcache_not_cached',
+        'qcache_queries_in_cache',
+        'qcache_total_blocks',
+        'questions',
+        'select_full_join',
+        'select_full_range_join',
+        'select_range',
+        'select_range_check',
+        'select_scan',
+        'slave_open_temp_tables',
+        'slave_retried_transactions',
+        'slow_launch_threads',
+        'slow_queries',
+        'sort_range',
+        'sort_rows',
+        'sort_scan',
+        'table_locks_immediate',
+        'table_locks_waited',
+        'threads_cached',
+        'threads_connected',
+        'threads_created',
+        'threads_running',
+        'uptime',
+    )
 
-	mysql_stats['open_files_used'] = int(global_status['open_files']) / int(variables['open_files_limit'])
+    non_delta = (
+        'max_used_connections',
+        'open_files',
+        'open_tables',
+        'qcache_free_blocks',
+        'qcache_free_memory',
+        'qcache_total_blocks',
+        'slave_open_temp_tables',
+        'threads_cached',
+        'threads_connected',
+        'threads_running',
+        'uptime'
+    )
 
-	innodb_delta = (
-		'data_fsyncs',
-		'data_reads',
-		'data_writes',
-		'log_writes'
-	)
+    # don't put all of global_status in mysql_stats b/c it's so big
+    for key in interesting_global_status_vars:
+        if key in non_delta:
+            mysql_stats[key] = global_status[key]
+        else:
+            # Calculate deltas for counters
+            if time_delta <= 0:
+                #systemclock was set backwards, nog updating values.. to smooth over the graphs
+                pass
+            elif key in mysql_stats_last:
+                if delta_per_second:
+                    mysql_stats[key] = (int(global_status[key]) - int(mysql_stats_last[key])) / time_delta
+                else:
+                    mysql_stats[key] = int(global_status[key]) - int(mysql_stats_last[key])
+            else:
+                mysql_stats[key] = float(0)
 
-	# process innodb status
-	if get_innodb:
-		for istat in innodb_status:
-			key = 'innodb_' + istat
+            mysql_stats_last[key] = global_status[key]
 
-			if istat in innodb_delta:
-				# Calculate deltas for counters
-				if time_delta <= 0:
-					#systemclock was set backwards, nog updating values.. to smooth over the graphs
-					pass
-				elif key in mysql_stats_last:
-					if delta_per_second:
-						mysql_stats[key] = (int(innodb_status[istat]) - int(mysql_stats_last[key])) / time_delta
-					else:
-						mysql_stats[key] = int(innodb_status[istat]) - int(mysql_stats_last[key])
-				else:
-					mysql_stats[key] = float(0)
+    mysql_stats['open_files_used'] = int(global_status['open_files']) / int(variables['open_files_limit'])
 
-				mysql_stats_last[key] = innodb_status[istat]
+    innodb_delta = (
+        'data_fsyncs',
+        'data_reads',
+        'data_writes',
+        'log_writes'
+    )
 
-			else:
-				mysql_stats[key] = innodb_status[istat]
+    # process innodb status
+    if get_innodb:
+        for istat in innodb_status:
+            key = 'innodb_' + istat
 
-	# process master logs
-	if get_master:
-		mysql_stats['binlog_count'] = len(master_logs)
-		mysql_stats['binlog_space_current'] = master_logs[-1][1]
-		#mysql_stats['binlog_space_total'] = sum((long(s[1]) for s in master_logs))
-		mysql_stats['binlog_space_total'] = 0
-		for s in master_logs:
-			mysql_stats['binlog_space_total'] += int(s[1])
-		mysql_stats['binlog_space_used'] = float(master_logs[-1][1]) / float(variables['max_binlog_size']) * 100
+            if istat in innodb_delta:
+                # Calculate deltas for counters
+                if time_delta <= 0:
+                    #systemclock was set backwards, nog updating values.. to smooth over the graphs
+                    pass
+                elif key in mysql_stats_last:
+                    if delta_per_second:
+                        mysql_stats[key] = (int(innodb_status[istat]) - int(mysql_stats_last[key])) / time_delta
+                    else:
+                        mysql_stats[key] = int(innodb_status[istat]) - int(mysql_stats_last[key])
+                else:
+                    mysql_stats[key] = float(0)
 
-	# process slave status
-	if get_slave:
-		mysql_stats['slave_exec_master_log_pos'] = slave_status['exec_master_log_pos']
-		#mysql_stats['slave_io'] = 1 if slave_status['slave_io_running'].lower() == "yes" else 0
-		if slave_status['slave_io_running'].lower() == "yes":
-			mysql_stats['slave_io'] = 1
-		else:
-			mysql_stats['slave_io'] = 0
-		#mysql_stats['slave_sql'] = 1 if slave_status['slave_sql_running'].lower() =="yes" else 0
-		if slave_status['slave_sql_running'].lower() == "yes":
-			mysql_stats['slave_sql'] = 1
-		else:
-			mysql_stats['slave_sql'] = 0
-		mysql_stats['slave_lag'] = slave_status['seconds_behind_master']
-		mysql_stats['slave_relay_log_pos'] = slave_status['relay_log_pos']
-		mysql_stats['slave_relay_log_space'] = slave_status['relay_log_space']
+                mysql_stats_last[key] = innodb_status[istat]
 
+            else:
+                mysql_stats[key] = innodb_status[istat]
 
-	logging.debug('success updating stats')
-	logging.debug('mysql_stats: ' + str(mysql_stats))
+    # process master logs
+    if get_master:
+        mysql_stats['binlog_count'] = len(master_logs)
+        mysql_stats['binlog_space_current'] = master_logs[-1][1]
+        #mysql_stats['binlog_space_total'] = sum((long(s[1]) for s in master_logs))
+        mysql_stats['binlog_space_total'] = 0
+        for s in master_logs:
+            mysql_stats['binlog_space_total'] += int(s[1])
+        mysql_stats['binlog_space_used'] = float(master_logs[-1][1]) / float(variables['max_binlog_size']) * 100
+
+    # process slave status
+    if get_slave:
+        mysql_stats['slave_exec_master_log_pos'] = slave_status['exec_master_log_pos']
+        #mysql_stats['slave_io'] = 1 if slave_status['slave_io_running'].lower() == "yes" else 0
+        if slave_status['slave_io_running'].lower() == "yes":
+            mysql_stats['slave_io'] = 1
+        else:
+            mysql_stats['slave_io'] = 0
+        #mysql_stats['slave_sql'] = 1 if slave_status['slave_sql_running'].lower() =="yes" else 0
+        if slave_status['slave_sql_running'].lower() == "yes":
+            mysql_stats['slave_sql'] = 1
+        else:
+            mysql_stats['slave_sql'] = 0
+        mysql_stats['slave_lag'] = slave_status['seconds_behind_master']
+        mysql_stats['slave_relay_log_pos'] = slave_status['relay_log_pos']
+        mysql_stats['slave_relay_log_space'] = slave_status['relay_log_space']
+
+    logging.debug('success updating stats')
+    logging.debug('mysql_stats: ' + str(mysql_stats))
+
 
 def get_stat(name):
-	logging.info("getting stat: %s" % name)
-	global mysql_stats
-	#logging.debug(mysql_stats)
+    logging.info("getting stat: %s" % name)
+    global mysql_stats
+    #logging.debug(mysql_stats)
 
-	global REPORT_INNODB
-	global REPORT_MASTER
-	global REPORT_SLAVE
+    global REPORT_INNODB
+    global REPORT_MASTER
+    global REPORT_SLAVE
 
-	ret = update_stats(REPORT_INNODB, REPORT_MASTER, REPORT_SLAVE)
+    ret = update_stats(REPORT_INNODB, REPORT_MASTER, REPORT_SLAVE)
 
-	if ret:
-		if name.startswith('mysql_'):
-			label = name[6:]
-		else:
-			label = name
+    if ret:
+        if name.startswith('mysql_'):
+            label = name[6:]
+        else:
+            label = name
 
-		logging.debug("fetching %s" % name)
-		try:
-			return mysql_stats[label]
-		except:
-			logging.error("failed to fetch %s" % name)
-			return 0
-	else:
-		return 0
+        logging.debug("fetching %s" % name)
+        try:
+            return mysql_stats[label]
+        except:
+            logging.error("failed to fetch %s" % name)
+            return 0
+    else:
+        return 0
 
 def metric_init(params):
-	global descriptors
-	global mysql_conn_opts
-	global mysql_stats
-	global delta_per_second
-
-	global REPORT_INNODB
-	global REPORT_MASTER
-	global REPORT_SLAVE
-
-	REPORT_INNODB = str(params.get('get_innodb', True)) == "True"
-	REPORT_MASTER = str(params.get('get_master', True)) == "True"
-	REPORT_SLAVE  = str(params.get('get_slave', True)) == "True"
-
-	logging.debug("init: " + str(params))
-
-	mysql_conn_opts = dict(
-		host = params.get('host', 'localhost'),
-		user = params.get('user'),
-		passwd = params.get('passwd'),
-		port = int(params.get('port', 3306)),
-		connect_timeout = int(params.get('timeout', 30)),
-	)
-	if params.get('unix_socket', '') != '':
-		mysql_conn_opts['unix_socket'] = params.get('unix_socket')
-
-	if params.get("delta_per_second", '') != '':
-		delta_per_second = True
-
-	master_stats_descriptions = {}
-	innodb_stats_descriptions = {}
-	slave_stats_descriptions  = {}
-
-	misc_stats_descriptions = dict(
-		aborted_clients = {
-			'description': 'The number of connections that were aborted because the client died without closing the connection properly',
-			'value_type': 'float',
-			'units': 'clients',
-		}, 
-
-		aborted_connects = {
-			'description': 'The number of failed attempts to connect to the MySQL server',
-			'value_type': 'float',
-			'units': 'conns',
-		}, 
-
-		binlog_cache_disk_use = {
-			'description': 'The number of transactions that used the temporary binary log cache but that exceeded the value of binlog_cache_size and used a temporary file to store statements from the transaction',
-			'value_type': 'float',
-			'units': 'txns',
-		}, 
-
-		binlog_cache_use = {
-			'description': ' The number of transactions that used the temporary binary log cache',
-			'value_type': 'float',
-			'units': 'txns',
-		}, 
-
-		bytes_received = {
-			'description': 'The number of bytes received from all clients',
-			'value_type': 'float',
-			'units': 'bytes',
-		}, 
-
-		bytes_sent = {
-			'description': ' The number of bytes sent to all clients',
-			'value_type': 'float',
-			'units': 'bytes',
-		}, 
-
-		com_delete = {
-			'description': 'The number of DELETE statements',
-			'value_type': 'float',
-			'units': 'stmts',
-		}, 
-
-		com_delete_multi = {
-			'description': 'The number of multi-table DELETE statements',
-			'value_type': 'float',
-			'units': 'stmts',
-		}, 
-
-		com_insert = {
-			'description': 'The number of INSERT statements',
-			'value_type': 'float',
-			'units': 'stmts',
-		}, 
-
-		com_insert_select = {
-			'description': 'The number of INSERT ... SELECT statements',
-			'value_type': 'float',
-			'units': 'stmts',
-		}, 
-
-		com_load = {
-			'description': 'The number of LOAD statements',
-			'value_type': 'float',
-			'units': 'stmts',
-		}, 
-
-		com_replace = {
-			'description': 'The number of REPLACE statements',
-			'value_type': 'float',
-			'units': 'stmts',
-		}, 
-
-		com_replace_select = {
-			'description': 'The number of REPLACE ... SELECT statements',
-			'value_type': 'float',
-			'units': 'stmts',
-		}, 
-
-		com_select = {
-			'description': 'The number of SELECT statements',
-			'value_type': 'float',
-			'units': 'stmts',
-		}, 
-
-		com_update = {
-			'description': 'The number of UPDATE statements',
-			'value_type': 'float',
-			'units': 'stmts',
-		}, 
-
-		com_update_multi = {
-			'description': 'The number of multi-table UPDATE statements',
-			'value_type': 'float',
-			'units': 'stmts',
-		}, 
-
-		connections = {
-			'description': 'The number of connection attempts (successful or not) to the MySQL server',
-			'value_type': 'float',
-			'units': 'conns',
-		}, 
-
-		created_tmp_disk_tables = {
-			'description': 'The number of temporary tables on disk created automatically by the server while executing statements',
-			'value_type': 'float',
-			'units': 'tables',
-		}, 
-
-		created_tmp_files = {
-			'description': 'The number of temporary files mysqld has created',
-			'value_type': 'float',
-			'units': 'files',
-		}, 
-
-		created_tmp_tables = {
-			'description': 'The number of in-memory temporary tables created automatically by the server while executing statement',
-			'value_type': 'float',
-			'units': 'tables',
-		}, 
-
-		#TODO in graphs: key_read_cache_miss_rate = key_reads / key_read_requests
-
-		key_read_requests = {
-			'description': 'The number of requests to read a key block from the cache',
-			'value_type': 'float',
-			'units': 'reqs',
-		}, 
-
-		key_reads = {
-			'description': 'The number of physical reads of a key block from disk',
-			'value_type': 'float',
-			'units': 'reads',
-		}, 
-
-		key_write_requests = {
-			'description': 'The number of requests to write a key block to the cache',
-			'value_type': 'float',
-			'units': 'reqs',
-		}, 
-
-		key_writes = {
-			'description': 'The number of physical writes of a key block to disk',
-			'value_type': 'float',
-			'units': 'writes',
-		}, 
-
-		max_used_connections = {
-			'description': 'The maximum number of connections that have been in use simultaneously since the server started',
-			'units': 'conns',
-			'slope': 'both',
-		}, 
-
-		open_files = {
-			'description': 'The number of files that are open',
-			'units': 'files',
-			'slope': 'both',
-		}, 
-
-		open_tables = {
-			'description': 'The number of tables that are open',
-			'units': 'tables',
-			'slope': 'both',
-		}, 
-
-		# If Opened_tables is big, your table_cache value is probably too small. 
-		opened_tables = {
-			'description': 'The number of tables that have been opened',
-			'value_type': 'float',
-			'units': 'tables',
-		}, 
-
-		qcache_free_blocks = {
-			'description': 'The number of free memory blocks in the query cache',
-			'units': 'blocks',
-			'slope': 'both',
-		}, 
-
-		qcache_free_memory = {
-			'description': 'The amount of free memory for the query cache',
-			'units': 'bytes',
-			'slope': 'both',
-		}, 
-
-		qcache_hits = {
-			'description': 'The number of query cache hits',
-			'value_type': 'float',
-			'units': 'hits',
-		}, 
-
-		qcache_inserts = {
-			'description': 'The number of queries added to the query cache',
-			'value_type': 'float',
-			'units': 'queries',
-		}, 
-
-		qcache_lowmem_prunes = {
-			'description': 'The number of queries that were deleted from the query cache because of low memory',
-			'value_type': 'float',
-			'units': 'queries',
-		}, 
-
-		qcache_not_cached = {
-			'description': 'The number of non-cached queries (not cacheable, or not cached due to the query_cache_type setting)',
-			'value_type': 'float',
-			'units': 'queries',
-		}, 
-
-		qcache_queries_in_cache = {
-			'description': 'The number of queries registered in the query cache',
-			'value_type': 'float',
-			'units': 'queries',
-		}, 
-
-		qcache_total_blocks = {
-			'description': 'The total number of blocks in the query cache',
-			'units': 'blocks',
-		}, 
-
-		questions = {
-			'description': 'The number of statements that clients have sent to the server',
-			'value_type': 'float',
-			'units': 'stmts',
-		}, 
-
-		# If this value is not 0, you should carefully check the indexes of your tables.
-		select_full_join = {
-			'description': 'The number of joins that perform table scans because they do not use indexes',
-			'value_type': 'float',
-			'units': 'joins',
-		}, 
-
-		select_full_range_join = {
-			'description': 'The number of joins that used a range search on a reference table',
-			'value_type': 'float',
-			'units': 'joins',
-		}, 
-
-		select_range = {
-			'description': 'The number of joins that used ranges on the first table',
-			'value_type': 'float',
-			'units': 'joins',
-		}, 
-
-		# If this is not 0, you should carefully check the indexes of your tables.
-		select_range_check = {
-			'description': 'The number of joins without keys that check for key usage after each row',
-			'value_type': 'float',
-			'units': 'joins',
-		}, 
-
-		select_scan = {
-			'description': 'The number of joins that did a full scan of the first table',
-			'value_type': 'float',
-			'units': 'joins',
-		}, 
-
-		slave_open_temp_tables = {
-			'description': 'The number of temporary tables that the slave SQL thread currently has open',
-			'value_type': 'float',
-			'units': 'tables',
-			'slope': 'both',
-		}, 
-
-		slave_retried_transactions = {
-			'description': 'The total number of times since startup that the replication slave SQL thread has retried transactions',
-			'value_type': 'float',
-			'units': 'count',
-		}, 
-
-		slow_launch_threads = {
-			'description': 'The number of threads that have taken more than slow_launch_time seconds to create',
-			'value_type': 'float',
-			'units': 'threads',
-		}, 
-
-		slow_queries = {
-			'description': 'The number of queries that have taken more than long_query_time seconds',
-			'value_type': 'float',
-			'units': 'queries',
-		}, 
-
-		sort_range = {
-			'description': 'The number of sorts that were done using ranges',
-			'value_type': 'float',
-			'units': 'sorts',
-		}, 
-
-		sort_rows = {
-			'description': 'The number of sorted rows',
-			'value_type': 'float',
-			'units': 'rows',
-		}, 
-
-		sort_scan = {
-			'description': 'The number of sorts that were done by scanning the table',
-			'value_type': 'float',
-			'units': 'sorts',
-		}, 
-
-		table_locks_immediate = {
-			'description': 'The number of times that a request for a table lock could be granted immediately',
-			'value_type': 'float',
-			'units': 'count',
-		}, 
-
-		# If this is high and you have performance problems, you should first optimize your queries, and then either split your table or tables or use replication.
-		table_locks_waited = {
-			'description': 'The number of times that a request for a table lock could not be granted immediately and a wait was needed',
-			'value_type': 'float',
-			'units': 'count',
-		}, 
-
-		threads_cached = {
-			'description': 'The number of threads in the thread cache',
-			'units': 'threads',
-			'slope': 'both',
-		}, 
-
-		threads_connected = {
-			'description': 'The number of currently open connections',
-			'units': 'threads',
-			'slope': 'both',
-		}, 
-
-		#TODO in graphs: The cache miss rate can be calculated as Threads_created/Connections
-
-		# Threads_created is big, you may want to increase the thread_cache_size value. 
-		threads_created = {
-			'description': 'The number of threads created to handle connections',
-			'value_type': 'float',
-			'units': 'threads',
-		}, 
-
-		threads_running = {
-			'description': 'The number of threads that are not sleeping',
-			'units': 'threads',
-			'slope': 'both',
-		}, 
-
-		uptime = {
-			'description': 'The number of seconds that the server has been up',
-			'units': 'secs',
-			'slope': 'both',
-		}, 
-
-		version = {
-			'description': "MySQL Version",
-			'value_type': 'string',
-		    'format': '%s',
-		},
-
-		max_connections = {
-			'description': "The maximum permitted number of simultaneous client connections",
-			'slope': 'zero',
-		},
-
-		query_cache_size = {
-			'description': "The amount of memory allocated for caching query results",
-			'slope': 'zero',
-		}
-	)
-
-	if REPORT_MASTER:
-		master_stats_descriptions = dict(
-			binlog_count = {
-				'description': "Number of binary logs",
-				'units': 'logs',
-				'slope': 'both',
-			},
-
-			binlog_space_current = {
-				'description': "Size of current binary log",
-				'units': 'bytes',
-				'slope': 'both',
-			},
-
-			binlog_space_total = {
-				'description': "Total space used by binary logs",
-				'units': 'bytes',
-				'slope': 'both',
-			},
-
-			binlog_space_used = {
-				'description': "Current binary log size / max_binlog_size",
-				'value_type': 'float',
-				'units': 'percent',
-				'slope': 'both',
-			},
-		)
-
-	if REPORT_SLAVE:
-		slave_stats_descriptions = dict(
-			slave_exec_master_log_pos = {
-				'description': "The position of the last event executed by the SQL thread from the master's binary log",
-				'units': 'bytes',
-				'slope': 'both',
-			},
-
-			slave_io = {
-				'description': "Whether the I/O thread is started and has connected successfully to the master",
-				'value_type': 'uint8',
-				'units': 'True/False',
-				'slope': 'both',
-			},
-
-			slave_lag = {
-				'description': "Replication Lag",
-				'units': 'secs',
-				'slope': 'both',
-			},
-
-			slave_relay_log_pos = {
-				'description': "The position up to which the SQL thread has read and executed in the current relay log",
-				'units': 'bytes',
-				'slope': 'both',
-			},
-
-			slave_sql = {
-				'description': "Slave SQL Running",
-				'value_type': 'uint8',
-				'units': 'True/False',
-				'slope': 'both',
-			},
-		)
-
-	if REPORT_INNODB:
-		innodb_stats_descriptions = dict(
-			innodb_active_transactions = {
-				'description': "Active InnoDB transactions",
-				'value_type':'uint',
-				'units': 'txns',
-				'slope': 'both',
-			},
-
-			innodb_current_transactions = {
-				'description': "Current InnoDB transactions",
-				'value_type':'uint',
-				'units': 'txns',
-				'slope': 'both',
-			},
-
-			innodb_buffer_pool_pages_data = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'pages',
-			},
-
-			innodb_data_fsyncs = {
-				'description': "The number of fsync() operations",
-				'value_type':'float',
-				'units': 'fsyncs',
-			},
-
-			innodb_data_reads = {
-				'description': "The number of data reads",
-				'value_type':'float',
-				'units': 'reads',
-			},
-
-			innodb_data_writes = {
-				'description': "The number of data writes",
-				'value_type':'float',
-				'units': 'writes',
-			},
-
-			innodb_buffer_pool_pages_free = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'pages',
-				'slope': 'both',
-			},
-
-			innodb_history_list = {
-				'description': "InnoDB",
-				'units': 'length',
-				'slope': 'both',
-			},
-
-			innodb_ibuf_inserts = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'inserts',
-			},
-
-			innodb_ibuf_merged = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'recs',
-			},
-
-			innodb_ibuf_merges = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'merges',
-			},
-
-			innodb_log_bytes_flushed = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'bytes',
-			},
-
-			innodb_log_bytes_unflushed = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'bytes',
-				'slope': 'both',
-			},
-
-			innodb_log_bytes_written = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'bytes',
-			},
-
-			innodb_log_writes = {
-				'description': "The number of physical writes to the log file",
-				'value_type':'float',
-				'units': 'writes',
-			},
-
-			innodb_buffer_pool_pages_dirty = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'pages',
-				'slope': 'both',
-			},
-
-			innodb_os_waits = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'waits',
-			},
-
-			innodb_pages_created = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'pages',
-			},
-
-			innodb_pages_read = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'pages',
-			},
-
-			innodb_pages_written = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'pages',
-			},
-
-			innodb_pending_aio_log_ios = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'ops',
-			},
-
-			innodb_pending_aio_sync_ios = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'ops',
-			},
-
-			innodb_pending_buffer_pool_flushes = {
-				'description': "The number of pending buffer pool page-flush requests",
-				'value_type':'uint',
-				'units': 'reqs',
-				'slope': 'both',
-			},
-
-			innodb_pending_chkp_writes = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'writes',
-			},
-
-			innodb_pending_ibuf_aio_reads = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'reads',
-			},
-
-			innodb_pending_log_flushes = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'reqs',
-			},
-
-			innodb_pending_log_writes = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'writes',
-			},
-
-			innodb_pending_normal_aio_reads = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'reads',
-			},
-
-			innodb_pending_normal_aio_writes = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'writes',
-			},
-
-			innodb_buffer_pool_pages_bytes = {
-				'description': "The total size of buffer pool, in bytes",
-				'value_type':'uint',
-				'units': 'bytes',
-				'slope': 'both',
-			},
-
-			innodb_buffer_pool_pages_total = {
-				'description': "The total size of buffer pool, in pages",
-				'value_type':'uint',
-				'units': 'pages',
-				'slope': 'both',
-			},
-
-			innodb_queries_inside = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'queries',
-			},
-
-			innodb_queries_queued = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'queries',
-				'slope': 'both',
-			},
-
-			innodb_read_views = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'views',
-			},
-
-			innodb_rows_deleted = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'rows',
-			},
-
-			innodb_rows_inserted = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'rows',
-			},
-
-			innodb_rows_read = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'rows',
-			},
-
-			innodb_rows_updated = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'rows',
-			},
-
-			innodb_spin_rounds = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'spins',
-				'slope': 'both',
-			},
-
-			innodb_spin_waits = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'spins',
-				'slope': 'both',
-			},
-
-			innodb_transactions = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'txns',
-			},
-
-			innodb_transactions_purged = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'txns',
-			},
-
-			innodb_transactions_unpurged = {
-				'description': "InnoDB",
-				'value_type':'uint',
-				'units': 'txns',
-			},
-		)
-
-	update_stats(REPORT_INNODB, REPORT_MASTER, REPORT_SLAVE)
-
-	time.sleep(MAX_UPDATE_TIME)
-	update_stats(REPORT_INNODB, REPORT_MASTER, REPORT_SLAVE)
-
-	for stats_descriptions in (innodb_stats_descriptions, master_stats_descriptions, misc_stats_descriptions, slave_stats_descriptions):
-		for label in stats_descriptions:
-			if mysql_stats.has_key(label):
-				format = '%u'
-				if stats_descriptions[label].has_key('value_type'):
-					if stats_descriptions[label]['value_type'] == "float":
-						format = '%f'
-
-				d = {
-					'name': 'mysql_' + label,
-					'call_back': get_stat,
-					'time_max': 60,
-					'value_type': "uint",
-					'units': "",
-					'slope': "both",
-					'format': format,
-					'description': "http://search.mysql.com/search?q=" + label,
-					'groups': 'mysql',
-				}
-
-				d.update(stats_descriptions[label])
-
-				descriptors.append(d)
-
-			else:
-				logging.error("skipped " + label)
-
-	#logging.debug(str(descriptors))
-	return descriptors
+    global descriptors
+    global mysql_conn_opts
+    global mysql_stats
+    global delta_per_second
+
+    global REPORT_INNODB
+    global REPORT_MASTER
+    global REPORT_SLAVE
+
+    REPORT_INNODB = str(params.get('get_innodb', True)) == "True"
+    REPORT_MASTER = str(params.get('get_master', True)) == "True"
+    REPORT_SLAVE = str(params.get('get_slave', True)) == "True"
+
+    logging.debug("init: " + str(params))
+
+    mysql_conn_opts = dict(
+        host = params.get('host', 'localhost'),
+        user = params.get('user'),
+        passwd = params.get('passwd'),
+        port = int(params.get('port', 3306)),
+        connect_timeout = int(params.get('timeout', 30)),
+    )
+    if params.get('unix_socket', '') != '':
+        mysql_conn_opts['unix_socket'] = params.get('unix_socket')
+
+    if params.get("delta_per_second", '') != '':
+        delta_per_second = True
+
+    master_stats_descriptions = {}
+    innodb_stats_descriptions = {}
+    slave_stats_descriptions = {}
+
+    misc_stats_descriptions = dict(
+        aborted_clients = {
+            'description': 'The number of connections that were aborted because the client died without closing the connection properly',
+            'value_type': 'float',
+            'units': 'clients',
+        },
+
+        aborted_connects = {
+            'description': 'The number of failed attempts to connect to the MySQL server',
+            'value_type': 'float',
+            'units': 'conns',
+        },
+
+        binlog_cache_disk_use = {
+            'description': 'The number of transactions that used the temporary binary log cache but that exceeded the value of binlog_cache_size and used a temporary file to store statements from the transaction',
+            'value_type': 'float',
+            'units': 'txns',
+        },
+
+        binlog_cache_use = {
+            'description': ' The number of transactions that used the temporary binary log cache',
+            'value_type': 'float',
+            'units': 'txns',
+        },
+
+        bytes_received = {
+            'description': 'The number of bytes received from all clients',
+            'value_type': 'float',
+            'units': 'bytes',
+        },
+
+        bytes_sent = {
+            'description': ' The number of bytes sent to all clients',
+            'value_type': 'float',
+            'units': 'bytes',
+        },
+
+        com_delete = {
+            'description': 'The number of DELETE statements',
+            'value_type': 'float',
+            'units': 'stmts',
+        },
+
+        com_delete_multi = {
+            'description': 'The number of multi-table DELETE statements',
+            'value_type': 'float',
+            'units': 'stmts',
+        },
+
+        com_insert = {
+            'description': 'The number of INSERT statements',
+            'value_type': 'float',
+            'units': 'stmts',
+        },
+
+        com_insert_select = {
+            'description': 'The number of INSERT ... SELECT statements',
+            'value_type': 'float',
+            'units': 'stmts',
+        },
+
+        com_load = {
+            'description': 'The number of LOAD statements',
+            'value_type': 'float',
+            'units': 'stmts',
+        },
+
+        com_replace = {
+            'description': 'The number of REPLACE statements',
+            'value_type': 'float',
+            'units': 'stmts',
+        },
+
+        com_replace_select = {
+            'description': 'The number of REPLACE ... SELECT statements',
+            'value_type': 'float',
+            'units': 'stmts',
+        },
+
+        com_select = {
+            'description': 'The number of SELECT statements',
+            'value_type': 'float',
+            'units': 'stmts',
+        },
+
+        com_update = {
+            'description': 'The number of UPDATE statements',
+            'value_type': 'float',
+            'units': 'stmts',
+        },
+
+        com_update_multi = {
+            'description': 'The number of multi-table UPDATE statements',
+            'value_type': 'float',
+            'units': 'stmts',
+        },
+
+        connections = {
+            'description': 'The number of connection attempts (successful or not) to the MySQL server',
+            'value_type': 'float',
+            'units': 'conns',
+        },
+
+        created_tmp_disk_tables = {
+            'description': 'The number of temporary tables on disk created automatically by the server while executing statements',
+            'value_type': 'float',
+            'units': 'tables',
+        },
+
+        created_tmp_files = {
+            'description': 'The number of temporary files mysqld has created',
+            'value_type': 'float',
+            'units': 'files',
+        },
+
+        created_tmp_tables = {
+            'description': 'The number of in-memory temporary tables created automatically by the server while executing statement',
+            'value_type': 'float',
+            'units': 'tables',
+        },
+
+        #TODO in graphs: key_read_cache_miss_rate = key_reads / key_read_requests
+
+        key_read_requests = {
+            'description': 'The number of requests to read a key block from the cache',
+            'value_type': 'float',
+            'units': 'reqs',
+        },
+
+        key_reads = {
+            'description': 'The number of physical reads of a key block from disk',
+            'value_type': 'float',
+            'units': 'reads',
+        },
+
+        key_write_requests = {
+            'description': 'The number of requests to write a key block to the cache',
+            'value_type': 'float',
+            'units': 'reqs',
+        },
+
+        key_writes = {
+            'description': 'The number of physical writes of a key block to disk',
+            'value_type': 'float',
+            'units': 'writes',
+        },
+
+        max_used_connections = {
+            'description': 'The maximum number of connections that have been in use simultaneously since the server started',
+            'units': 'conns',
+            'slope': 'both',
+        },
+
+        open_files = {
+            'description': 'The number of files that are open',
+            'units': 'files',
+            'slope': 'both',
+        },
+
+        open_tables = {
+            'description': 'The number of tables that are open',
+            'units': 'tables',
+            'slope': 'both',
+        },
+
+        # If Opened_tables is big, your table_cache value is probably too small.
+        opened_tables = {
+            'description': 'The number of tables that have been opened',
+            'value_type': 'float',
+            'units': 'tables',
+        },
+
+        qcache_free_blocks = {
+            'description': 'The number of free memory blocks in the query cache',
+            'units': 'blocks',
+            'slope': 'both',
+        },
+
+        qcache_free_memory = {
+            'description': 'The amount of free memory for the query cache',
+            'units': 'bytes',
+            'slope': 'both',
+        },
+
+        qcache_hits = {
+            'description': 'The number of query cache hits',
+            'value_type': 'float',
+            'units': 'hits',
+        },
+
+        qcache_inserts = {
+            'description': 'The number of queries added to the query cache',
+            'value_type': 'float',
+            'units': 'queries',
+        },
+
+        qcache_lowmem_prunes = {
+            'description': 'The number of queries that were deleted from the query cache because of low memory',
+            'value_type': 'float',
+            'units': 'queries',
+        },
+
+        qcache_not_cached = {
+            'description': 'The number of non-cached queries (not cacheable, or not cached due to the query_cache_type setting)',
+            'value_type': 'float',
+            'units': 'queries',
+        },
+
+        qcache_queries_in_cache = {
+            'description': 'The number of queries registered in the query cache',
+            'value_type': 'float',
+            'units': 'queries',
+        },
+
+        qcache_total_blocks = {
+            'description': 'The total number of blocks in the query cache',
+            'units': 'blocks',
+        },
+
+        questions = {
+            'description': 'The number of statements that clients have sent to the server',
+            'value_type': 'float',
+            'units': 'stmts',
+        },
+
+        # If this value is not 0, you should carefully check the indexes of your tables.
+        select_full_join = {
+            'description': 'The number of joins that perform table scans because they do not use indexes',
+            'value_type': 'float',
+            'units': 'joins',
+        },
+
+        select_full_range_join = {
+            'description': 'The number of joins that used a range search on a reference table',
+            'value_type': 'float',
+            'units': 'joins',
+        },
+
+        select_range = {
+            'description': 'The number of joins that used ranges on the first table',
+            'value_type': 'float',
+            'units': 'joins',
+        },
+
+        # If this is not 0, you should carefully check the indexes of your tables.
+        select_range_check = {
+            'description': 'The number of joins without keys that check for key usage after each row',
+            'value_type': 'float',
+            'units': 'joins',
+        },
+
+        select_scan = {
+            'description': 'The number of joins that did a full scan of the first table',
+            'value_type': 'float',
+            'units': 'joins',
+        },
+
+        slave_open_temp_tables = {
+            'description': 'The number of temporary tables that the slave SQL thread currently has open',
+            'value_type': 'float',
+            'units': 'tables',
+            'slope': 'both',
+        },
+
+        slave_retried_transactions = {
+            'description': 'The total number of times since startup that the replication slave SQL thread has retried transactions',
+            'value_type': 'float',
+            'units': 'count',
+        },
+
+        slow_launch_threads = {
+            'description': 'The number of threads that have taken more than slow_launch_time seconds to create',
+            'value_type': 'float',
+            'units': 'threads',
+        },
+
+        slow_queries = {
+            'description': 'The number of queries that have taken more than long_query_time seconds',
+            'value_type': 'float',
+            'units': 'queries',
+        },
+
+        sort_range = {
+            'description': 'The number of sorts that were done using ranges',
+            'value_type': 'float',
+            'units': 'sorts',
+        },
+
+        sort_rows = {
+            'description': 'The number of sorted rows',
+            'value_type': 'float',
+            'units': 'rows',
+        },
+
+        sort_scan = {
+            'description': 'The number of sorts that were done by scanning the table',
+            'value_type': 'float',
+            'units': 'sorts',
+        },
+
+        table_locks_immediate = {
+            'description': 'The number of times that a request for a table lock could be granted immediately',
+            'value_type': 'float',
+            'units': 'count',
+        },
+
+        # If this is high and you have performance problems, you should first optimize your queries, and then either split your table or tables or use replication.
+        table_locks_waited = {
+            'description': 'The number of times that a request for a table lock could not be granted immediately and a wait was needed',
+            'value_type': 'float',
+            'units': 'count',
+        },
+
+        threads_cached = {
+            'description': 'The number of threads in the thread cache',
+            'units': 'threads',
+            'slope': 'both',
+        },
+
+        threads_connected = {
+            'description': 'The number of currently open connections',
+            'units': 'threads',
+            'slope': 'both',
+        },
+
+        #TODO in graphs: The cache miss rate can be calculated as Threads_created/Connections
+
+        # Threads_created is big, you may want to increase the thread_cache_size value.
+        threads_created = {
+            'description': 'The number of threads created to handle connections',
+            'value_type': 'float',
+            'units': 'threads',
+        },
+
+        threads_running = {
+            'description': 'The number of threads that are not sleeping',
+            'units': 'threads',
+            'slope': 'both',
+        },
+
+        uptime = {
+            'description': 'The number of seconds that the server has been up',
+            'units': 'secs',
+            'slope': 'both',
+        },
+
+        version = {
+            'description': "MySQL Version",
+            'value_type': 'string',
+            'format': '%s',
+        },
+
+        max_connections = {
+            'description': "The maximum permitted number of simultaneous client connections",
+            'slope': 'zero',
+        },
+
+        query_cache_size = {
+            'description': "The amount of memory allocated for caching query results",
+            'slope': 'zero',
+        }
+    )
+
+    if REPORT_MASTER:
+        master_stats_descriptions = dict(
+            binlog_count = {
+                'description': "Number of binary logs",
+                'units': 'logs',
+                'slope': 'both',
+            },
+
+            binlog_space_current = {
+                'description': "Size of current binary log",
+                'units': 'bytes',
+                'slope': 'both',
+            },
+
+            binlog_space_total = {
+                'description': "Total space used by binary logs",
+                'units': 'bytes',
+                'slope': 'both',
+            },
+
+            binlog_space_used = {
+                'description': "Current binary log size / max_binlog_size",
+                'value_type': 'float',
+                'units': 'percent',
+                'slope': 'both',
+            },
+        )
+
+    if REPORT_SLAVE:
+        slave_stats_descriptions = dict(
+            slave_exec_master_log_pos = {
+                'description': "The position of the last event executed by the SQL thread from the master's binary log",
+                'units': 'bytes',
+                'slope': 'both',
+            },
+
+            slave_io = {
+                'description': "Whether the I/O thread is started and has connected successfully to the master",
+                'value_type': 'uint8',
+                'units': 'True/False',
+                'slope': 'both',
+            },
+
+            slave_lag = {
+                'description': "Replication Lag",
+                'units': 'secs',
+                'slope': 'both',
+            },
+
+            slave_relay_log_pos = {
+                'description': "The position up to which the SQL thread has read and executed in the current relay log",
+                'units': 'bytes',
+                'slope': 'both',
+            },
+
+            slave_sql = {
+                'description': "Slave SQL Running",
+                'value_type': 'uint8',
+                'units': 'True/False',
+                'slope': 'both',
+            },
+        )
+
+    if REPORT_INNODB:
+        innodb_stats_descriptions = dict(
+            innodb_active_transactions = {
+                'description': "Active InnoDB transactions",
+                'value_type':'uint',
+                'units': 'txns',
+                'slope': 'both',
+            },
+
+            innodb_current_transactions = {
+                'description': "Current InnoDB transactions",
+                'value_type':'uint',
+                'units': 'txns',
+                'slope': 'both',
+            },
+
+            innodb_buffer_pool_pages_data = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'pages',
+            },
+
+            innodb_data_fsyncs = {
+                'description': "The number of fsync() operations",
+                'value_type':'float',
+                'units': 'fsyncs',
+            },
+
+            innodb_data_reads = {
+                'description': "The number of data reads",
+                'value_type':'float',
+                'units': 'reads',
+            },
+
+            innodb_data_writes = {
+                'description': "The number of data writes",
+                'value_type':'float',
+                'units': 'writes',
+            },
+
+            innodb_buffer_pool_pages_free = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'pages',
+                'slope': 'both',
+            },
+
+            innodb_history_list = {
+                'description': "InnoDB",
+                'units': 'length',
+                'slope': 'both',
+            },
+
+            innodb_ibuf_inserts = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'inserts',
+            },
+
+            innodb_ibuf_merged = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'recs',
+            },
+
+            innodb_ibuf_merges = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'merges',
+            },
+
+            innodb_log_bytes_flushed = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'bytes',
+            },
+
+            innodb_log_bytes_unflushed = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'bytes',
+                'slope': 'both',
+            },
+
+            innodb_log_bytes_written = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'bytes',
+            },
+
+            innodb_log_writes = {
+                'description': "The number of physical writes to the log file",
+                'value_type':'float',
+                'units': 'writes',
+            },
+
+            innodb_buffer_pool_pages_dirty = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'pages',
+                'slope': 'both',
+            },
+
+            innodb_os_waits = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'waits',
+            },
+
+            innodb_pages_created = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'pages',
+            },
+
+            innodb_pages_read = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'pages',
+            },
+
+            innodb_pages_written = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'pages',
+            },
+
+            innodb_pending_aio_log_ios = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'ops',
+            },
+
+            innodb_pending_aio_sync_ios = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'ops',
+            },
+
+            innodb_pending_buffer_pool_flushes = {
+                'description': "The number of pending buffer pool page-flush requests",
+                'value_type':'uint',
+                'units': 'reqs',
+                'slope': 'both',
+            },
+
+            innodb_pending_chkp_writes = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'writes',
+            },
+
+            innodb_pending_ibuf_aio_reads = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'reads',
+            },
+
+            innodb_pending_log_flushes = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'reqs',
+            },
+
+            innodb_pending_log_writes = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'writes',
+            },
+
+            innodb_pending_normal_aio_reads = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'reads',
+            },
+
+            innodb_pending_normal_aio_writes = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'writes',
+            },
+
+            innodb_buffer_pool_pages_bytes = {
+                'description': "The total size of buffer pool, in bytes",
+                'value_type':'uint',
+                'units': 'bytes',
+                'slope': 'both',
+            },
+
+            innodb_buffer_pool_pages_total = {
+                'description': "The total size of buffer pool, in pages",
+                'value_type':'uint',
+                'units': 'pages',
+                'slope': 'both',
+            },
+
+            innodb_queries_inside = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'queries',
+            },
+
+            innodb_queries_queued = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'queries',
+                'slope': 'both',
+            },
+
+            innodb_read_views = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'views',
+            },
+
+            innodb_rows_deleted = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'rows',
+            },
+
+            innodb_rows_inserted = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'rows',
+            },
+
+            innodb_rows_read = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'rows',
+            },
+
+            innodb_rows_updated = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'rows',
+            },
+
+            innodb_spin_rounds = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'spins',
+                'slope': 'both',
+            },
+
+            innodb_spin_waits = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'spins',
+                'slope': 'both',
+            },
+
+            innodb_transactions = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'txns',
+            },
+
+            innodb_transactions_purged = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'txns',
+            },
+
+            innodb_transactions_unpurged = {
+                'description': "InnoDB",
+                'value_type':'uint',
+                'units': 'txns',
+            },
+        )
+
+    update_stats(REPORT_INNODB, REPORT_MASTER, REPORT_SLAVE)
+
+    time.sleep(MAX_UPDATE_TIME)
+    update_stats(REPORT_INNODB, REPORT_MASTER, REPORT_SLAVE)
+
+    for stats_descriptions in (innodb_stats_descriptions, master_stats_descriptions, misc_stats_descriptions, slave_stats_descriptions):
+        for label in stats_descriptions:
+            if mysql_stats.has_key(label):
+                format = '%u'
+                if stats_descriptions[label].has_key('value_type'):
+                    if stats_descriptions[label]['value_type'] == "float":
+                        format = '%f'
+
+                d = {
+                    'name': 'mysql_' + label,
+                    'call_back': get_stat,
+                    'time_max': 60,
+                    'value_type': "uint",
+                    'units': "",
+                    'slope': "both",
+                    'format': format,
+                    'description': "http://search.mysql.com/search?q=" + label,
+                    'groups': 'mysql',
+                }
+
+                d.update(stats_descriptions[label])
+
+                descriptors.append(d)
+
+            else:
+                logging.error("skipped " + label)
+
+    #logging.debug(str(descriptors))
+    return descriptors
+
 
 def metric_cleanup():
-	logging.shutdown()
-	# pass
+    logging.shutdown()
+    # pass
 
 if __name__ == '__main__':
-	from optparse import OptionParser
-	import os
+    from optparse import OptionParser
+    import os
 
-	logging.debug('running from cmd line')
-	parser = OptionParser()
-	parser.add_option("-H", "--Host", dest="host", help="Host running mysql", default="localhost")
-	parser.add_option("-u", "--user", dest="user", help="user to connect as", default="")
-	parser.add_option("-p", "--password", dest="passwd", help="password", default="")
-	parser.add_option("-P", "--port", dest="port", help="port", default=3306, type="int")
-	parser.add_option("-S", "--socket", dest="unix_socket", help="unix_socket", default="")
-	parser.add_option("--no-innodb", dest="get_innodb", action="store_false", default=True)
-	parser.add_option("--no-master", dest="get_master", action="store_false", default=True)
-	parser.add_option("--no-slave", dest="get_slave", action="store_false", default=True)
-	parser.add_option("-b", "--gmetric-bin", dest="gmetric_bin", help="path to gmetric binary", default="/usr/bin/gmetric")
-	parser.add_option("-c", "--gmond-conf", dest="gmond_conf", help="path to gmond.conf", default="/etc/ganglia/gmond.conf")
-	parser.add_option("-g", "--gmetric", dest="gmetric", help="submit via gmetric", action="store_true", default=False)
-	parser.add_option("-q", "--quiet", dest="quiet", action="store_true", default=False)
+    logging.debug('running from cmd line')
+    parser = OptionParser()
+    parser.add_option("-H", "--Host", dest="host", help="Host running mysql", default="localhost")
+    parser.add_option("-u", "--user", dest="user", help="user to connect as", default="")
+    parser.add_option("-p", "--password", dest="passwd", help="password", default="")
+    parser.add_option("-P", "--port", dest="port", help="port", default=3306, type="int")
+    parser.add_option("-S", "--socket", dest="unix_socket", help="unix_socket", default="")
+    parser.add_option("--no-innodb", dest="get_innodb", action="store_false", default=True)
+    parser.add_option("--no-master", dest="get_master", action="store_false", default=True)
+    parser.add_option("--no-slave", dest="get_slave", action="store_false", default=True)
+    parser.add_option("-b", "--gmetric-bin", dest="gmetric_bin", help="path to gmetric binary", default="/usr/bin/gmetric")
+    parser.add_option("-c", "--gmond-conf", dest="gmond_conf", help="path to gmond.conf", default="/etc/ganglia/gmond.conf")
+    parser.add_option("-g", "--gmetric", dest="gmetric", help="submit via gmetric", action="store_true", default=False)
+    parser.add_option("-q", "--quiet", dest="quiet", action="store_true", default=False)
 
-	(options, args) = parser.parse_args()
+    (options, args) = parser.parse_args()
 
-	metric_init({
-		'host': options.host,
-		'passwd': options.passwd,
-		'user': options.user,
-		'port': options.port,
-		'get_innodb': options.get_innodb,
-		'get_master': options.get_master,
-		'get_slave': options.get_slave,
-		'unix_socket': options.unix_socket,
-	})
+    metric_init({
+        'host': options.host,
+        'passwd': options.passwd,
+        'user': options.user,
+        'port': options.port,
+        'get_innodb': options.get_innodb,
+        'get_master': options.get_master,
+        'get_slave': options.get_slave,
+        'unix_socket': options.unix_socket,
+    })
 
-	for d in descriptors:
-		v = d['call_back'](d['name'])
-		if not options.quiet:
-			print ' %s: %s %s [%s]' % (d['name'], v, d['units'], d['description'])
+    for d in descriptors:
+        v = d['call_back'](d['name'])
+        if not options.quiet:
+            print ' %s: %s %s [%s]' % (d['name'], v, d['units'], d['description'])
 
-		if options.gmetric:
-			if d['value_type'] == 'uint':
-				value_type = 'uint32'
-			else:
-				value_type = d['value_type']
+        if options.gmetric:
+            if d['value_type'] == 'uint':
+                value_type = 'uint32'
+            else:
+                value_type = d['value_type']
 
-			cmd = "%s --conf=%s --value='%s' --units='%s' --type='%s' --name='%s' --slope='%s'" % \
-				(options.gmetric_bin, options.gmond_conf, v, d['units'], value_type, d['name'], d['slope'])
-			os.system(cmd)
-
+            cmd = "%s --conf=%s --value='%s' --units='%s' --type='%s' --name='%s' --slope='%s'" % \
+                (options.gmetric_bin, options.gmond_conf, v, d['units'], value_type, d['name'], d['slope'])
+            os.system(cmd)

--- a/gmond/python_modules/db/redis.py
+++ b/gmond/python_modules/db/redis.py
@@ -1,3 +1,23 @@
+# ## DESCRIPTION
+# Redis plugin for Ganglia that exposes most of the counters in the
+# Redis `INFO` command to Ganglia for all your graphing needs.  The
+# metrics it comes with are pretty rudimentary but they get the job
+# done.
+#
+# ## FILES
+# ## THEME SONG
+#
+# The Arcade Fire - "Wake Up"
+#
+# ## SEE ALSO
+# The Redis `INFO` command is described at <http://code.google.com/p/redis/wiki/InfoCommand>.
+#
+# The original blog post on this plugin is at
+# <http://rcrowley.org/2010/06/24/redis-in-ganglia.html>.  Gil
+# Raphaelli's MySQL plugin, on which this one is based can be found at
+# <http://g.raphaelli.com/2009/1/5/ganglia-mysql-metrics>.
+
+
 import socket
 import time
 #import logging

--- a/gmond/python_modules/db/redis.py
+++ b/gmond/python_modules/db/redis.py
@@ -17,13 +17,13 @@
 # Raphaelli's MySQL plugin, on which this one is based can be found at
 # <http://g.raphaelli.com/2009/1/5/ganglia-mysql-metrics>.
 
-
 import socket
 import time
 #import logging
 
 #logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s\t Thread-%(thread)d - %(message)s", filename='/tmp/gmond.log', filemode='w')
 #logging.debug('starting up')
+
 
 def metric_handler(name):
 
@@ -82,7 +82,7 @@ def metric_handler(name):
                           metric_handler.prev_total_commands = int(v)
                           v = cps
                   #logging.debug("submittincg metric %s is %s" % (n, int(v)))
-                  metric_handler.info[n] = int(v) # TODO Use value_type.
+                  metric_handler.info[n] = int(v)  # TODO Use value_type.
         except Exception, e:
             #logging.debug("caught exception %s" % e)
             pass
@@ -91,6 +91,7 @@ def metric_handler(name):
 
     #logging.debug("returning metric_handl: %s %s %s" % (metric_handler.info.get(name, 0), metric_handler.info, metric_handler))
     return metric_handler.info.get(name, 0)
+
 
 def metric_init(params={}):
     metric_handler.host = params.get("host", "127.0.0.1")
@@ -109,9 +110,9 @@ def metric_init(params={}):
         "master_sync_in_progress": {"units": "yes/no"},
         "master_link_status": {"units": "yes/no"},
         #"aof_bgrewriteaof_in_progress": {"units": "yes/no"},
-        "total_connections_received": { "units": "connections/sec" },
+        "total_connections_received": {"units": "connections/sec"},
         "instantaneous_ops_per_sec": {"units": "ops"},
-        "total_commands_processed": { "units": "commands/sec" },
+        "total_commands_processed": {"units": "commands/sec"},
         "expired_keys": {"units": "keys"},
         "pubsub_channels": {"units": "channels"},
         "pubsub_patterns": {"units": "patterns"},
@@ -135,6 +136,7 @@ def metric_init(params={}):
         descriptor.update(updates)
         metric_handler.descriptors[name] = descriptor
     return metric_handler.descriptors.values()
+
 
 def metric_cleanup():
     pass

--- a/gmond/python_modules/db/redis.py
+++ b/gmond/python_modules/db/redis.py
@@ -1,5 +1,9 @@
 import socket
 import time
+#import logging
+
+#logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s\t Thread-%(thread)d - %(message)s", filename='/tmp/gmond.log', filemode='w')
+#logging.debug('starting up')
 
 def metric_handler(name):
 
@@ -7,50 +11,93 @@ def metric_handler(name):
     if 15 < time.time() - metric_handler.timestamp:
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.connect((metric_handler.host, metric_handler.port))
-        s.send("INFO\n")
+        if metric_handler.auth is not None:
+            s.send("*2\r\n$4\r\nAUTH\r\n$%d\r\n%s\r\n" % (len(metric_handler.auth), metric_handler.auth))
+            result = s.recv(100)
+            if not 'OK' in result:
+                return 0
+        s.send("*1\r\n$4\r\nINFO\r\n")
+        #logging.debug("sent INFO")
         info = s.recv(4096)
+        #logging.debug("rcvd INFO")
         if "$" != info[0]:
             return 0
-        len = int(info[1:info.find("\n")])
-        if 4096 < len:
-            info += s.recv(len - 4096)
+        msglen = int(info[1:info.find("\n")])
+        if 4096 < msglen:
+            info += s.recv(msglen - 4096)
         metric_handler.info = {}
-        for line in info.splitlines()[1:]:
-            if "" == line:
-                continue
-            n, v = line.split(":")
-            if n in metric_handler.descriptors:
-                metric_handler.info[n] = int(v) # TODO Use value_type.
+        try:
+          for line in info.splitlines()[1:]:
+              #logging.debug("line is %s done" % line)
+              if "" == line:
+                  continue
+              if "#" == line[0]:
+                  continue
+              n, v = line.split(":")
+              if n in metric_handler.descriptors:
+                  if n == "master_sync_status":
+                      v = 1 if v == 'up' else 0
+                  if n == "db0":
+                      v = v.split('=')[1].split(',')[0]
+                  if n == "used_memory":
+                      v = int(int(v) / 1000)
+                  if n == "total_connections_received":
+                      # first run, zero out and record total connections
+                      if metric_handler.prev_total_connections == 0:
+                          metric_handler.prev_total_connections = int(v)
+                          v = 0
+                      else:
+                          # calculate connections per second
+                          cps = (int(v) - metric_handler.prev_total_connections) / (time.time() - metric_handler.timestamp)
+                          metric_handler.prev_total_connections = int(v)
+                          v = cps
+                  if n == "total_commands_processed":
+                      # first run, zero out and record total commands
+                      if metric_handler.prev_total_commands == 0:
+                          metric_handler.prev_total_commands = int(v)
+                          v = 0
+                      else:
+                          # calculate commands per second
+                          cps = (int(v) - metric_handler.prev_total_commands) / (time.time() - metric_handler.timestamp)
+                          metric_handler.prev_total_commands = int(v)
+                          v = cps
+                  #logging.debug("submittincg metric %s is %s" % (n, int(v)))
+                  metric_handler.info[n] = int(v) # TODO Use value_type.
+        except Exception, e:
+            #logging.debug("caught exception %s" % e)
+            pass
         s.close()
         metric_handler.timestamp = time.time()
 
+    #logging.debug("returning metric_handl: %s %s %s" % (metric_handler.info.get(name, 0), metric_handler.info, metric_handler))
     return metric_handler.info.get(name, 0)
 
 def metric_init(params={}):
     metric_handler.host = params.get("host", "127.0.0.1")
     metric_handler.port = int(params.get("port", 6379))
+    metric_handler.auth = params.get("auth", None)
     metric_handler.timestamp = 0
+    metric_handler.prev_total_commands = 0
+    metric_handler.prev_total_connections = 0
     metrics = {
         "connected_clients": {"units": "clients"},
         "connected_slaves": {"units": "slaves"},
         "blocked_clients": {"units": "clients"},
-        "used_memory": {"units": "bytes"},
-        "changes_since_last_save": {"units": "changes"},
-        "bgsave_in_progress": {"units": "yes/no"},
-        "bgrewriteaof_in_progress": {"units": "yes/no"},
-        "total_connections_received": {
-            "units": "connections",
-            "slope": "positive",
-        },
-        "total_commands_processed": {
-            "units": "commands",
-            "slope": "positive",
-        },
+        "used_memory": {"units": "KB"},
+        "rdb_changes_since_last_save": {"units": "changes"},
+        "rdb_bgsave_in_progress": {"units": "yes/no"},
+        "master_sync_in_progress": {"units": "yes/no"},
+        "master_link_status": {"units": "yes/no"},
+        #"aof_bgrewriteaof_in_progress": {"units": "yes/no"},
+        "total_connections_received": { "units": "connections/sec" },
+        "instantaneous_ops_per_sec": {"units": "ops"},
+        "total_commands_processed": { "units": "commands/sec" },
         "expired_keys": {"units": "keys"},
         "pubsub_channels": {"units": "channels"},
         "pubsub_patterns": {"units": "patterns"},
-        "vm_enabled": {"units": "yes/no"},
+        #"vm_enabled": {"units": "yes/no"},
         "master_last_io_seconds_ago": {"units": "seconds ago"},
+        "db0": {"units": "keys"},
     }
     metric_handler.descriptors = {}
     for name, updates in metrics.iteritems():

--- a/gmond/python_modules/db/riak.py
+++ b/gmond/python_modules/db/riak.py
@@ -29,14 +29,16 @@ import traceback
 import json
 
 descriptors = list()
-Desc_Skel   = {}
+Desc_Skel = {}
 _Worker_Thread = None
-_Lock = threading.Lock() # synchronization lock
+_Lock = threading.Lock()  # synchronization lock
 Debug = False
+
 
 def dprint(f, *v):
     if Debug:
-        print >>sys.stderr, "DEBUG: "+f % v
+        print >>sys.stderr, "DEBUG: " + f % v
+
 
 def floatable(str):
     try:
@@ -45,19 +47,20 @@ def floatable(str):
     except:
         return False
 
+
 class UpdateMetricThread(threading.Thread):
 
     def __init__(self, params):
         threading.Thread.__init__(self)
-        self.running      = False
+        self.running = False
         self.shuttingdown = False
         self.refresh_rate = 30
         if "refresh_rate" in params:
             self.refresh_rate = int(params["refresh_rate"])
-        self.metric       = {}
-        self.timeout      = 10
+        self.metric = {}
+        self.timeout = 10
 
-        self.url          = "http://localhost:8098/stats"
+        self.url = "http://localhost:8098/stats"
         if "url" in params:
             self.url = params["url"]
         self.mp = params["metrix_prefix"]
@@ -81,7 +84,7 @@ class UpdateMetricThread(threading.Thread):
 
     def update_metric(self):
         try:
-            req = urllib2.Request(url = self.url)
+            req = urllib2.Request(url=self.url)
             res = urllib2.urlopen(req)
             stats = res.read()
             dprint("%s", stats)
@@ -89,9 +92,9 @@ class UpdateMetricThread(threading.Thread):
             for (key, value) in json_stats.iteritems():
                 dprint("%s = %s", key, value)
                 if value == 'undefined':
-                    self.metric[self.mp+'_'+key] = 0
+                    self.metric[self.mp + '_' + key] = 0
                 else:
-                    self.metric[self.mp+'_'+key] = value
+                    self.metric[self.mp + '_' + key] = value
         except urllib2.URLError:
             traceback.print_exc()
         else:
@@ -106,11 +109,12 @@ class UpdateMetricThread(threading.Thread):
             _Lock.release()
         return val
 
+
 def metric_init(params):
     global descriptors, Desc_Skel, _Worker_Thread, Debug
 
     if "metrix_prefix" not in params:
-      params["metrix_prefix"] = "riak"
+        params["metrix_prefix"] = "riak"
 
     print params
 
@@ -122,7 +126,7 @@ def metric_init(params):
         'value_type'  : 'uint',
         'format'      : '%u',
         'units'       : 'XXX',
-        'slope'       : 'XXX', # zero|positive|negative|both
+        'slope'       : 'XXX',  # zero|positive|negative|both
         'description' : 'XXX',
         'groups'      : 'riak',
         }
@@ -144,913 +148,916 @@ def metric_init(params):
 
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_riak_node_get_fsm_siblings_100",
+        "name": mp + "_riak_node_get_fsm_siblings_100",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_riak_node_get_fsm_siblings_95",
+        "name": mp + "_riak_node_get_fsm_siblings_95",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_riak_node_get_fsm_siblings_99",
+        "name": mp + "_riak_node_get_fsm_siblings_99",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_riak_node_get_fsm_siblings_mean",
+        "name": mp + "_riak_node_get_fsm_siblings_mean",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_riak_node_get_fsm_siblings_median",
+        "name": mp + "_riak_node_get_fsm_siblings_median",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_executing_mappers",
+        "name": mp + "_executing_mappers",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_node_get_fsm_active",
+        "name": mp + "_node_get_fsm_active",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_node_get_fsm_active_60s",
+        "name": mp + "_node_get_fsm_active_60s",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_node_get_fsm_in_rate",
+        "name": mp + "_node_get_fsm_in_rate",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_node_put_fsm_active_60s",
+        "name": mp + "_node_put_fsm_active_60s",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_node_put_fsm_in_rate",
+        "name": mp + "_node_put_fsm_in_rate",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_node_put_fsm_out_rate",
+        "name": mp + "_node_put_fsm_out_rate",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_pipeline_active",
+        "name": mp + "_pipeline_active",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_pipeline_create_count",
+        "name": mp + "_pipeline_create_count",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_pipeline_create_error_count",
+        "name": mp + "_pipeline_create_error_count",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_pipeline_create_error_one",
+        "name": mp + "_pipeline_create_error_one",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_pipeline_create_one",
+        "name": mp + "_pipeline_create_one",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_index_fsm_active",
+        "name": mp + "_index_fsm_active",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_index_fsm_create",
+        "name": mp + "_index_fsm_create",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_index_fsm_create_error",
+        "name": mp + "_index_fsm_create_error",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_list_fsm_active",
+        "name": mp + "_list_fsm_active",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_list_fsm_create",
+        "name": mp + "_list_fsm_create",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_list_fsm_create_error",
+        "name": mp + "_list_fsm_create_error",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_node_get_fsm_out_rate",
+        "name": mp + "_node_get_fsm_out_rate",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_node_get_fsm_rejected",
+        "name": mp + "_node_get_fsm_rejected",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_node_get_fsm_rejected_60s",
+        "name": mp + "_node_get_fsm_rejected_60s",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_node_get_fsm_siblings_100",
+        "name": mp + "_node_get_fsm_siblings_100",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_node_put_fsm_active",
+        "name": mp + "_node_put_fsm_active",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_node_put_fsm_rejected",
+        "name": mp + "_node_put_fsm_rejected",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_node_put_fsm_rejected_60s",
+        "name": mp + "_node_put_fsm_rejected_60s",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_read_repairs_primary_notfound_count",
+        "name": mp + "_read_repairs_primary_notfound_count",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_read_repairs_primary_notfound_one",
+        "name": mp + "_read_repairs_primary_notfound_one",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_read_repairs_primary_outofdate_count",
+        "name": mp + "_read_repairs_primary_outofdate_count",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_read_repairs_primary_outofdate_one",
+        "name": mp + "_read_repairs_primary_outofdate_one",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_rebalance_delay_mean",
+        "name": mp + "_rebalance_delay_mean",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_rejected_handoffs",
+        "name": mp + "_rejected_handoffs",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_riak_core_stat_ts",
+        "name": mp + "_riak_core_stat_ts",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_riak_kv_stat_ts",
+        "name": mp + "_riak_kv_stat_ts",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_riak_pipe_stat_ts",
+        "name": mp + "_riak_pipe_stat_ts",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_riak_pipe_vnodeq_mean",
+        "name": mp + "_riak_pipe_vnodeq_mean",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_rings_reconciled",
+        "name": mp + "_rings_reconciled",
     }))
     descriptors.append(create_desc(Desc_Skel, {
         "slope": "both",
-        "name": mp+"_vnode_index_refreshes",
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-        "slope": "both",  
-        "name": mp+"_node_puts", 
-        "units": "puts", 
-        "description": mp+"_node_puts"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_sys_logical_processors", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_sys_logical_processors"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "positive",  
-      "name": mp+"_ignored_gossip_total", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_ignored_gossip_total"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_vnode_gets", 
-      "units": "gets", 
-      "description": mp+"_vnode_gets"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_node_get_fsm_objsize_100", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_node_get_fsm_objsize_100"
+        "name": mp + "_vnode_index_refreshes",
     }))
     descriptors.append(create_desc(Desc_Skel, {
-        "name" : mp+"_node_put_fsm_time_mean",
-        "units" : "microseconds",
-        "slope" : "both",
-        "description": mp+"_node_put_fsm_time_mean",
-    }))
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "positive",  
-      "name": mp+"_node_puts_total", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_node_puts_total"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_riak_kv_vnodeq_mean", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_riak_kv_vnodeq_mean"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_riak_pipe_vnodes_running", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_riak_pipe_vnodes_running"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_vnode_index_writes_postings", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_vnode_index_writes_postings"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "positive",  
-      "name": mp+"_vnode_index_deletes_postings_total", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_vnode_index_deletes_postings_total"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "positive",  
-      "name": mp+"_read_repairs_total", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_read_repairs_total"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_precommit_fail", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_precommit_fail"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_rebalance_delay_max", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_rebalance_delay_max"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_converge_delay_mean", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_converge_delay_mean"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_node_get_fsm_time_95", 
-      "units": "microseconds", 
-      "description": mp+"_node_get_fsm_time_95"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_riak_pipe_vnodeq_median", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_riak_pipe_vnodeq_median"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_node_get_fsm_time_99", 
-      "value_type": "uint",  
-      "units": "microseconds", 
-      "description": mp+"_node_get_fsm_time_99"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_memory_code", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_memory_code"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_sys_smp_support", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_sys_smp_support"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_memory_processes_used", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_memory_processes_used"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_pbc_active", 
-      "units": "connections", 
-      "description": mp+"_pbc_active"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "positive",  
-      "name": mp+"_vnode_index_writes_postings_total", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_vnode_index_writes_postings_total"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "positive",  
-      "name": mp+"_vnode_gets_total", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_vnode_gets_total"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_sys_process_count", 
-      "units": "processes", 
-      "description": "Erlang processes"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_read_repairs", 
-      "units": "repairs", 
-      "description": mp+"_read_repairs"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_vnode_puts", 
-      "units": "puts", 
-      "description": mp+"_vnode_puts"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_riak_search_vnodes_running", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_riak_search_vnodes_running"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_riak_pipe_vnodeq_min", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_riak_pipe_vnodeq_min"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_node_get_fsm_objsize_mean", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_node_get_fsm_objsize_mean"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_cpu_nprocs", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_cpu_nprocs"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_node_put_fsm_time_100", 
-      "units": "microseconds", 
-      "description": mp+"_node_put_fsm_time_100"
-    }))
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_mem_total", 
-      "format": "%.1f", 
-      "value_type": "float",  
-      "units": "bytes", 
-      "description": mp+"_mem_total"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_riak_search_vnodeq_mean", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_riak_search_vnodeq_mean"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_node_get_fsm_siblings_median", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_node_get_fsm_siblings_median"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_riak_search_vnodeq_max", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_riak_search_vnodeq_max"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_sys_threads_enabled", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_sys_threads_enabled"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_vnode_index_writes", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_vnode_index_writes"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "positive",  
-      "name": mp+"_memory_total", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_memory_total"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_riak_pipe_vnodeq_max", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_riak_pipe_vnodeq_max"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_vnode_index_deletes_postings", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_vnode_index_deletes_postings"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_node_get_fsm_time_mean", 
-      "units": "microseconds", 
-      "description": "Mean for riak_kv_get_fsm calls"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_ring_num_partitions", 
-      "units": "vnodes", 
-      "description": mp+"_ring_num_partitions"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_riak_search_vnodeq_min", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_riak_search_vnodeq_min"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "positive",  
-      "name": mp+"_vnode_index_reads_total", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_vnode_index_reads_total"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_node_get_fsm_siblings_99", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_node_get_fsm_siblings_99"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_mem_allocated", 
-      "format": "%.1f", 
-      "value_type": "float",  
-      "units": "bytes", 
-      "description": mp+"_mem_allocated"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_node_get_fsm_siblings_95", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_node_get_fsm_siblings_95"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_node_get_fsm_objsize_95", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_node_get_fsm_objsize_95"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_node_put_fsm_time_median", 
-      "units": "microseconds", 
-      "description": mp+"_node_put_fsm_time_median"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_memory_processes", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_memory_processes"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "positive",  
-      "name": mp+"_riak_search_vnodeq_total", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_riak_search_vnodeq_total"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_node_get_fsm_objsize_99", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_node_get_fsm_objsize_99"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_memory_system", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_memory_system"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_sys_global_heaps_size", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_sys_global_heaps_size"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_gossip_received", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_gossip_received"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_node_get_fsm_time_median", 
-      "units": "microseconds", 
-      "description": mp+"_node_get_fsm_time_median"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "positive",  
-      "name": mp+"_vnode_index_deletes_total", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_vnode_index_deletes_total"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_riak_kv_vnodeq_max", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_riak_kv_vnodeq_max"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_riak_kv_vnodeq_min", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_riak_kv_vnodeq_min"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_node_gets", 
-      "units": "gets", 
-      "description": mp+"_node_gets"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_riak_kv_vnodeq_median", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_riak_kv_vnodeq_median"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_postcommit_fail", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_postcommit_fail"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_riak_search_vnodeq_median", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_riak_search_vnodeq_median"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_sys_wordsize", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_sys_wordsize"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_riak_kv_vnodes_running", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_riak_kv_vnodes_running"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_node_put_fsm_time_95", 
-      "units": "microseconds", 
-      "description": mp+"_node_put_fsm_time_95",
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "positive",  
-      "name": mp+"_rings_reconciled_total", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_rings_reconciled_total"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_rebalance_delay_min", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_rebalance_delay_min"
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_node_put_fsm_time_99", 
-      "units": "microseconds", 
-      "description": mp+"_node_put_fsm_time_99",
-    })) 
-    descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_ring_creation_size", 
-      "units": "vnodes", 
-      "description": mp+"_ring_creation_size"
+        "slope": "both",
+        "name": mp + "_node_puts",
+        "units": "puts",
+        "description": mp + "_node_puts"
     }))
     descriptors.append(create_desc(Desc_Skel, {
       "slope": "both",
-      "name": mp+"_cpu_avg1",
+      "name": mp + "_sys_logical_processors",
       "format": "%u",
       "value_type": "uint",
       "units": "N",
-      "description": mp+"_cpu_avg1"
-    })) 
+      "description": mp + "_sys_logical_processors"
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_cpu_avg5", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_cpu_avg5"
-    })) 
+      "slope": "positive",
+      "name": mp + "_ignored_gossip_total",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_ignored_gossip_total"
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-      "slope": "positive",  
-      "name": mp+"_pbc_connects_total", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_pbc_connects_total"
-    })) 
+      "slope": "both",
+      "name": mp + "_vnode_gets",
+      "units": "gets",
+      "description": mp + "_vnode_gets"
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_memory_binary", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_memory_binary"
-    })) 
+      "slope": "both",
+      "name": mp + "_node_get_fsm_objsize_100",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_node_get_fsm_objsize_100"
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-      "slope": "positive",  
-      "name": mp+"_coord_redirs_total", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_coord_redirs_total"
-    })) 
+        "name": mp + "_node_put_fsm_time_mean",
+        "units": "microseconds",
+        "slope": "both",
+        "description": mp + "_node_put_fsm_time_mean",
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-      "slope": "positive",  
-      "name": mp+"_riak_pipe_vnodeq_total", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_riak_pipe_vnodeq_total"
-    })) 
+      "slope": "positive",
+      "name": mp + "_node_puts_total",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_node_puts_total"
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-      "slope": "positive",  
-      "name": mp+"_node_gets_total", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_node_gets_total"
-    })) 
+      "slope": "both",
+      "name": mp + "_riak_kv_vnodeq_mean",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_riak_kv_vnodeq_mean"
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-      "slope": "positive",  
-      "name": mp+"_vnode_puts_total", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_vnode_puts_total"
-    })) 
+      "slope": "both",
+      "name": mp + "_riak_pipe_vnodes_running",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_riak_pipe_vnodes_running"
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_memory_atom", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_memory_atom"
-    })) 
+      "slope": "both",
+      "name": mp + "_vnode_index_writes_postings",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_vnode_index_writes_postings"
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_cpu_avg15", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_cpu_avg15"
-    })) 
+      "slope": "positive",
+      "name": mp + "_vnode_index_deletes_postings_total",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_vnode_index_deletes_postings_total"
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_node_get_fsm_objsize_median", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_node_get_fsm_objsize_median"
-    })) 
+      "slope": "positive",
+      "name": mp + "_read_repairs_total",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_read_repairs_total"
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_node_get_fsm_siblings_mean", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_node_get_fsm_siblings_mean"
-    })) 
+      "slope": "both",
+      "name": mp + "_precommit_fail",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_precommit_fail"
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_converge_delay_min", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_converge_delay_min"
-    })) 
+      "slope": "both",
+      "name": mp + "_rebalance_delay_max",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_rebalance_delay_max"
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_node_get_fsm_time_100", 
-      "units": "microseconds", 
-      "description": mp+"_node_get_fsm_time_100"
-    })) 
+      "slope": "both",
+      "name": mp + "_converge_delay_mean",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_converge_delay_mean"
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_converge_delay_max", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_converge_delay_max"
-    })) 
+      "slope": "both",
+      "name": mp + "_node_get_fsm_time_95",
+      "units": "microseconds",
+      "description": mp + "_node_get_fsm_time_95"
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_converge_delay_last", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_converge_delay_last"
-    })) 
+      "slope": "both",
+      "name": mp + "_riak_pipe_vnodeq_median",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_riak_pipe_vnodeq_median"
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_rebalance_delay_last", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_rebalance_delay_last"
-    })) 
+      "slope": "both",
+      "name": mp + "_node_get_fsm_time_99",
+      "value_type": "uint",
+      "units": "microseconds",
+      "description": mp + "_node_get_fsm_time_99"
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_vnode_index_deletes", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_vnode_index_deletes"
-    })) 
+      "slope": "both",
+      "name": mp + "_memory_code",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_memory_code"
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-      "slope": "positive",  
-      "name": mp+"_riak_kv_vnodeq_total", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_riak_kv_vnodeq_total"
-    })) 
+      "slope": "both",
+      "name": mp + "_sys_smp_support",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_sys_smp_support"
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_handoff_timeouts", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_handoff_timeouts"
-    })) 
+      "slope": "both",
+      "name": mp + "_memory_processes_used",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_memory_processes_used"
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_vnode_index_reads", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_vnode_index_reads"
-    })) 
+      "slope": "both",
+      "name": mp + "_pbc_active",
+      "units": "connections",
+      "description": mp + "_pbc_active"
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_sys_thread_pool_size", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_sys_thread_pool_size"
-    })) 
+      "slope": "positive",
+      "name": mp + "_vnode_index_writes_postings_total",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_vnode_index_writes_postings_total"
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-      "slope": "both",  
-      "name": mp+"_pbc_connects", 
-      "format": "%u", 
-      "value_type": "uint",  
-      "units": "N", 
-      "description": mp+"_pbc_connects"
-    })) 
+      "slope": "positive",
+      "name": mp + "_vnode_gets_total",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_vnode_gets_total"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_sys_process_count",
+      "units": "processes",
+      "description": "Erlang processes"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_read_repairs",
+      "units": "repairs",
+      "description": mp + "_read_repairs"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_vnode_puts",
+      "units": "puts",
+      "description": mp + "_vnode_puts"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_riak_search_vnodes_running",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_riak_search_vnodes_running"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_riak_pipe_vnodeq_min",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_riak_pipe_vnodeq_min"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_node_get_fsm_objsize_mean",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_node_get_fsm_objsize_mean"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_cpu_nprocs",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_cpu_nprocs"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_node_put_fsm_time_100",
+      "units": "microseconds",
+      "description": mp + "_node_put_fsm_time_100"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_mem_total",
+      "format": "%.1f",
+      "value_type": "float",
+      "units": "bytes",
+      "description": mp + "_mem_total"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_riak_search_vnodeq_mean",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_riak_search_vnodeq_mean"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_node_get_fsm_siblings_median",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_node_get_fsm_siblings_median"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_riak_search_vnodeq_max",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_riak_search_vnodeq_max"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_sys_threads_enabled",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_sys_threads_enabled"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_vnode_index_writes",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_vnode_index_writes"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",
+      "name": mp + "_memory_total",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_memory_total"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_riak_pipe_vnodeq_max",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_riak_pipe_vnodeq_max"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_vnode_index_deletes_postings",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_vnode_index_deletes_postings"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_node_get_fsm_time_mean",
+      "units": "microseconds",
+      "description": "Mean for riak_kv_get_fsm calls"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_ring_num_partitions",
+      "units": "vnodes",
+      "description": mp + "_ring_num_partitions"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_riak_search_vnodeq_min",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_riak_search_vnodeq_min"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",
+      "name": mp + "_vnode_index_reads_total",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_vnode_index_reads_total"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_node_get_fsm_siblings_99",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_node_get_fsm_siblings_99"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_mem_allocated",
+      "format": "%.1f",
+      "value_type": "float",
+      "units": "bytes",
+      "description": mp + "_mem_allocated"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_node_get_fsm_siblings_95",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_node_get_fsm_siblings_95"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_node_get_fsm_objsize_95",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_node_get_fsm_objsize_95"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_node_put_fsm_time_median",
+      "units": "microseconds",
+      "description": mp + "_node_put_fsm_time_median"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_memory_processes",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_memory_processes"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",
+      "name": mp + "_riak_search_vnodeq_total",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_riak_search_vnodeq_total"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_node_get_fsm_objsize_99",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_node_get_fsm_objsize_99"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_memory_system",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_memory_system"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_sys_global_heaps_size",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_sys_global_heaps_size"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_gossip_received",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_gossip_received"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_node_get_fsm_time_median",
+      "units": "microseconds",
+      "description": mp + "_node_get_fsm_time_median"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",
+      "name": mp + "_vnode_index_deletes_total",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_vnode_index_deletes_total"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_riak_kv_vnodeq_max",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_riak_kv_vnodeq_max"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_riak_kv_vnodeq_min",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_riak_kv_vnodeq_min"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_node_gets",
+      "units": "gets",
+      "description": mp + "_node_gets"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_riak_kv_vnodeq_median",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_riak_kv_vnodeq_median"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_postcommit_fail",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_postcommit_fail"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_riak_search_vnodeq_median",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_riak_search_vnodeq_median"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_sys_wordsize",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_sys_wordsize"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_riak_kv_vnodes_running",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_riak_kv_vnodes_running"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_node_put_fsm_time_95",
+      "units": "microseconds",
+      "description": mp + "_node_put_fsm_time_95",
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",
+      "name": mp + "_rings_reconciled_total",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_rings_reconciled_total"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_rebalance_delay_min",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_rebalance_delay_min"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_node_put_fsm_time_99",
+      "units": "microseconds",
+      "description": mp + "_node_put_fsm_time_99",
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_ring_creation_size",
+      "units": "vnodes",
+      "description": mp + "_ring_creation_size"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_cpu_avg1",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_cpu_avg1"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_cpu_avg5",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_cpu_avg5"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",
+      "name": mp + "_pbc_connects_total",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_pbc_connects_total"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_memory_binary",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_memory_binary"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",
+      "name": mp + "_coord_redirs_total",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_coord_redirs_total"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",
+      "name": mp + "_riak_pipe_vnodeq_total",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_riak_pipe_vnodeq_total"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",
+      "name": mp + "_node_gets_total",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_node_gets_total"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",
+      "name": mp + "_vnode_puts_total",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_vnode_puts_total"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_memory_atom",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_memory_atom"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_cpu_avg15",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_cpu_avg15"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_node_get_fsm_objsize_median",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_node_get_fsm_objsize_median"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_node_get_fsm_siblings_mean",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_node_get_fsm_siblings_mean"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_converge_delay_min",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_converge_delay_min"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_node_get_fsm_time_100",
+      "units": "microseconds",
+      "description": mp + "_node_get_fsm_time_100"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_converge_delay_max",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_converge_delay_max"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_converge_delay_last",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_converge_delay_last"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_rebalance_delay_last",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_rebalance_delay_last"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_vnode_index_deletes",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_vnode_index_deletes"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",
+      "name": mp + "_riak_kv_vnodeq_total",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_riak_kv_vnodeq_total"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_handoff_timeouts",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_handoff_timeouts"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_vnode_index_reads",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_vnode_index_reads"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_sys_thread_pool_size",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_sys_thread_pool_size"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp + "_pbc_connects",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp + "_pbc_connects"
+    }))
 
-    
     return descriptors
+
 
 def create_desc(skel, prop):
     d = skel.copy()
-    for k,v in prop.iteritems():
+    for k, v in prop.iteritems():
         d[k] = v
     return d
+
 
 def metric_of(name):
     return _Worker_Thread.metric_of(name)
 
+
 def metric_cleanup():
     _Worker_Thread.shutdown()
+
 
 if __name__ == '__main__':
     try:
         params = {
-            "debug" : True,
+            "debug": True,
             }
         metric_init(params)
         while True:
             for d in descriptors:
                 v = d['call_back'](d['name'])
-                print ('value for %s is '+d['format']) % (d['name'],  v)
+                print ('value for %s is ' + d['format']) % (d['name'],  v)
             time.sleep(5)
     except KeyboardInterrupt:
         time.sleep(0.2)

--- a/gmond/python_modules/db/riak.py
+++ b/gmond/python_modules/db/riak.py
@@ -1,6 +1,25 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# [Riak](https://wiki.basho.com/display/RIAK/Riak) is a Dynamo-inspired
+# key/value store.
+#
+# This module collects metrics from the JSON stats interface of riak, available
+# at http://localhost:8098/stats. The statistics-aggregator must be enabled in
+# your riak configuration for this to work:
+#     {riak_kv, [
+#       %% ...
+#       {riak_kv_stat, true},
+#       %% ...
+#     ]},
+#
+# You'll want to edit the url key in riak.conf to point at the interface your
+# riak install is listening on:
+#
+#     param url {
+#         value = "http://10.0.1.123:8098/stats"
+#     }
+
 import os
 import sys
 import threading

--- a/gmond/python_modules/db/riak.py
+++ b/gmond/python_modules/db/riak.py
@@ -41,7 +41,7 @@ class UpdateMetricThread(threading.Thread):
         self.url          = "http://localhost:8098/stats"
         if "url" in params:
             self.url = params["url"]
-        self.mp      = params["metrix_prefix"]
+        self.mp = params["metrix_prefix"]
 
     def shutdown(self):
         self.shuttingdown = True
@@ -63,16 +63,16 @@ class UpdateMetricThread(threading.Thread):
     def update_metric(self):
         try:
             req = urllib2.Request(url = self.url)
-            res = urllib2.urlopen(req, None, 2)
+            res = urllib2.urlopen(req)
             stats = res.read()
             dprint("%s", stats)
             json_stats = json.loads(stats)
-            for (key,value) in json_stats.iteritems():
-              dprint("%s = %s", key, value)
-              if value == 'undefined':
-                self.metric[self.mp+'_'+key] = 0
-              else:
-                self.metric[self.mp+'_'+key] = value
+            for (key, value) in json_stats.iteritems():
+                dprint("%s = %s", key, value)
+                if value == 'undefined':
+                    self.metric[self.mp+'_'+key] = 0
+                else:
+                    self.metric[self.mp+'_'+key] = value
         except urllib2.URLError:
             traceback.print_exc()
         else:
@@ -124,156 +124,890 @@ def metric_init(params):
     mp = params["metrix_prefix"]
 
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_ring_creation_size",
-                "units"      : "vnodes",
-                "slope"      : "both",
-                "description": mp+"_ring_creation_size",
-                }))
-
+        "slope": "both",
+        "name": mp+"_riak_node_get_fsm_siblings_100",
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_node_get_fsm_time_mean",
-                "units"      : "microseconds",
-                "slope"      : "both",
-                "description": "Mean for riak_kv_get_fsm calls",
-                }))
-
+        "slope": "both",
+        "name": mp+"_riak_node_get_fsm_siblings_95",
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_pbc_active",
-                "units"      : "connections",
-                "slope"      : "both",
-                "description": "Active pb socket connections",
-                }))
-
+        "slope": "both",
+        "name": mp+"_riak_node_get_fsm_siblings_99",
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_node_put_fsm_time_100",
-                "units"      : "microseconds",
-                "slope"      : "both",
-                "description": "100th percentile for riak_kv_put_fsm calls",
-                }))
-
+        "slope": "both",
+        "name": mp+"_riak_node_get_fsm_siblings_mean",
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_node_put_fsm_time_mean",
-                "units"      : "microseconds",
-                "slope"      : "both",
-                "description": "Mean for riak_kv_put_fsm calls",
-                }))
-
+        "slope": "both",
+        "name": mp+"_riak_node_get_fsm_siblings_median",
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_node_get_fsm_time_95",
-                "units"      : "microseconds",
-                "slope"      : "both",
-                "description": "95th percentile for riak_kv_get_fsm calls",
-                }))
-
+        "slope": "both",
+        "name": mp+"_executing_mappers",
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_vnode_puts",
-                "units"      : "puts",
-                "slope"      : "both",
-                "description": "Puts handled by local vnodes in the last minute",
-                }))
-
+        "slope": "both",
+        "name": mp+"_node_get_fsm_active",
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_node_puts",
-                "units"      : "puts",
-                "slope"      : "both",
-                "description": "Puts coordinated by this node in the last minute",
-                }))
-
+        "slope": "both",
+        "name": mp+"_node_get_fsm_active_60s",
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_node_get_fsm_time_median",
-                "units"      : "microseconds",
-                "slope"      : "both",
-                "description": "Median for riak_kv_get_fsm calls",
-                }))
-
+        "slope": "both",
+        "name": mp+"_node_get_fsm_in_rate",
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_sys_process_count",
-                "units"      : "processes",
-                "slope"      : "both",
-                "description": "Erlang processes",
-                }))
-
+        "slope": "both",
+        "name": mp+"_node_put_fsm_active_60s",
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_node_put_fsm_time_median",
-                "units"      : "microseconds",
-                "slope"      : "both",
-                "description": "Median for riak_kv_put_fsm calls",
-                }))
-
+        "slope": "both",
+        "name": mp+"_node_put_fsm_in_rate",
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_node_put_fsm_time_95",
-                "units"      : "microseconds",
-                "slope"      : "both",
-                "description": "95th percentile for riak_kv_put_fsm calls",
-                }))
-
+        "slope": "both",
+        "name": mp+"_node_put_fsm_out_rate",
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_node_get_fsm_time_100",
-                "units"      : "microseconds",
-                "slope"      : "both",
-                "description": "100th percentile for riak_kv_get_fsm calls",
-                }))
-
+        "slope": "both",
+        "name": mp+"_pipeline_active",
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_node_get_fsm_time_99",
-                "units"      : "microseconds",
-                "slope"      : "both",
-                "description": "99th percentile for riak_kv_get_fsm calls",
-                }))
-
+        "slope": "both",
+        "name": mp+"_pipeline_create_count",
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_vnode_gets",
-                "units"      : "gets",
-                "slope"      : "both",
-                "description": "Gets handled by local vnodes in the last minute",
-                }))
-
+        "slope": "both",
+        "name": mp+"_pipeline_create_error_count",
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_read_repairs",
-                "units"      : "repairs",
-                "slope"      : "both",
-                "description": mp+"_read_repairs",
-                }))
-
+        "slope": "both",
+        "name": mp+"_pipeline_create_error_one",
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_ring_num_partitions",
-                "units"      : "vnodes",
-                "slope"      : "both",
-                "description": mp+"_ring_num_partitions",
-                }))
-
+        "slope": "both",
+        "name": mp+"_pipeline_create_one",
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_mem_total",
-                "units"      : "bytes",
-                "format"     : "%.1f",
-                'value_type'  : 'float',
-                "slope"      : "both",
-                "description": mp+"_mem_total",
-                }))
-
+        "slope": "both",
+        "name": mp+"_index_fsm_active",
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_node_gets",
-                "units"      : "gets",
-                "slope"      : "both",
-                "description": "Gets coordinated by this node in the last minute",
-                }))
-
+        "slope": "both",
+        "name": mp+"_index_fsm_create",
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_mem_allocated",
-                "units"      : "bytes",
-                "format"     : "%.1f",
-                'value_type'  : 'float',
-                "slope"      : "both",
-                "description": mp+"_mem_allocated",
-                }))
-
+        "slope": "both",
+        "name": mp+"_index_fsm_create_error",
+    }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_node_put_fsm_time_99",
-                "units"      : "microseconds",
-                "slope"      : "both",
-                "description": "99th percentile for riak_kv_put_fsm calls",
-                }))
+        "slope": "both",
+        "name": mp+"_list_fsm_active",
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+        "slope": "both",
+        "name": mp+"_list_fsm_create",
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+        "slope": "both",
+        "name": mp+"_list_fsm_create_error",
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+        "slope": "both",
+        "name": mp+"_node_get_fsm_out_rate",
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+        "slope": "both",
+        "name": mp+"_node_get_fsm_rejected",
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+        "slope": "both",
+        "name": mp+"_node_get_fsm_rejected_60s",
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+        "slope": "both",
+        "name": mp+"_node_get_fsm_siblings_100",
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+        "slope": "both",
+        "name": mp+"_node_put_fsm_active",
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+        "slope": "both",
+        "name": mp+"_node_put_fsm_rejected",
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+        "slope": "both",
+        "name": mp+"_node_put_fsm_rejected_60s",
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+        "slope": "both",
+        "name": mp+"_read_repairs_primary_notfound_count",
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+        "slope": "both",
+        "name": mp+"_read_repairs_primary_notfound_one",
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+        "slope": "both",
+        "name": mp+"_read_repairs_primary_outofdate_count",
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+        "slope": "both",
+        "name": mp+"_read_repairs_primary_outofdate_one",
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+        "slope": "both",
+        "name": mp+"_rebalance_delay_mean",
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+        "slope": "both",
+        "name": mp+"_rejected_handoffs",
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+        "slope": "both",
+        "name": mp+"_riak_core_stat_ts",
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+        "slope": "both",
+        "name": mp+"_riak_kv_stat_ts",
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+        "slope": "both",
+        "name": mp+"_riak_pipe_stat_ts",
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+        "slope": "both",
+        "name": mp+"_riak_pipe_vnodeq_mean",
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+        "slope": "both",
+        "name": mp+"_rings_reconciled",
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+        "slope": "both",
+        "name": mp+"_vnode_index_refreshes",
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+        "slope": "both",  
+        "name": mp+"_node_puts", 
+        "units": "puts", 
+        "description": mp+"_node_puts"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_sys_logical_processors", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_sys_logical_processors"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",  
+      "name": mp+"_ignored_gossip_total", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_ignored_gossip_total"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_vnode_gets", 
+      "units": "gets", 
+      "description": mp+"_vnode_gets"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_node_get_fsm_objsize_100", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_node_get_fsm_objsize_100"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+        "name" : mp+"_node_put_fsm_time_mean",
+        "units" : "microseconds",
+        "slope" : "both",
+        "description": mp+"_node_put_fsm_time_mean",
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",  
+      "name": mp+"_node_puts_total", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_node_puts_total"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_riak_kv_vnodeq_mean", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_riak_kv_vnodeq_mean"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_riak_pipe_vnodes_running", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_riak_pipe_vnodes_running"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_vnode_index_writes_postings", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_vnode_index_writes_postings"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",  
+      "name": mp+"_vnode_index_deletes_postings_total", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_vnode_index_deletes_postings_total"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",  
+      "name": mp+"_read_repairs_total", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_read_repairs_total"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_precommit_fail", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_precommit_fail"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_rebalance_delay_max", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_rebalance_delay_max"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_converge_delay_mean", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_converge_delay_mean"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_node_get_fsm_time_95", 
+      "units": "microseconds", 
+      "description": mp+"_node_get_fsm_time_95"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_riak_pipe_vnodeq_median", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_riak_pipe_vnodeq_median"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_node_get_fsm_time_99", 
+      "value_type": "uint",  
+      "units": "microseconds", 
+      "description": mp+"_node_get_fsm_time_99"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_memory_code", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_memory_code"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_sys_smp_support", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_sys_smp_support"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_memory_processes_used", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_memory_processes_used"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_pbc_active", 
+      "units": "connections", 
+      "description": mp+"_pbc_active"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",  
+      "name": mp+"_vnode_index_writes_postings_total", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_vnode_index_writes_postings_total"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",  
+      "name": mp+"_vnode_gets_total", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_vnode_gets_total"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_sys_process_count", 
+      "units": "processes", 
+      "description": "Erlang processes"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_read_repairs", 
+      "units": "repairs", 
+      "description": mp+"_read_repairs"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_vnode_puts", 
+      "units": "puts", 
+      "description": mp+"_vnode_puts"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_riak_search_vnodes_running", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_riak_search_vnodes_running"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_riak_pipe_vnodeq_min", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_riak_pipe_vnodeq_min"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_node_get_fsm_objsize_mean", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_node_get_fsm_objsize_mean"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_cpu_nprocs", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_cpu_nprocs"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_node_put_fsm_time_100", 
+      "units": "microseconds", 
+      "description": mp+"_node_put_fsm_time_100"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_mem_total", 
+      "format": "%.1f", 
+      "value_type": "float",  
+      "units": "bytes", 
+      "description": mp+"_mem_total"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_riak_search_vnodeq_mean", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_riak_search_vnodeq_mean"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_node_get_fsm_siblings_median", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_node_get_fsm_siblings_median"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_riak_search_vnodeq_max", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_riak_search_vnodeq_max"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_sys_threads_enabled", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_sys_threads_enabled"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_vnode_index_writes", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_vnode_index_writes"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",  
+      "name": mp+"_memory_total", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_memory_total"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_riak_pipe_vnodeq_max", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_riak_pipe_vnodeq_max"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_vnode_index_deletes_postings", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_vnode_index_deletes_postings"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_node_get_fsm_time_mean", 
+      "units": "microseconds", 
+      "description": "Mean for riak_kv_get_fsm calls"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_ring_num_partitions", 
+      "units": "vnodes", 
+      "description": mp+"_ring_num_partitions"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_riak_search_vnodeq_min", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_riak_search_vnodeq_min"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",  
+      "name": mp+"_vnode_index_reads_total", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_vnode_index_reads_total"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_node_get_fsm_siblings_99", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_node_get_fsm_siblings_99"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_mem_allocated", 
+      "format": "%.1f", 
+      "value_type": "float",  
+      "units": "bytes", 
+      "description": mp+"_mem_allocated"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_node_get_fsm_siblings_95", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_node_get_fsm_siblings_95"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_node_get_fsm_objsize_95", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_node_get_fsm_objsize_95"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_node_put_fsm_time_median", 
+      "units": "microseconds", 
+      "description": mp+"_node_put_fsm_time_median"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_memory_processes", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_memory_processes"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",  
+      "name": mp+"_riak_search_vnodeq_total", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_riak_search_vnodeq_total"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_node_get_fsm_objsize_99", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_node_get_fsm_objsize_99"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_memory_system", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_memory_system"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_sys_global_heaps_size", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_sys_global_heaps_size"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_gossip_received", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_gossip_received"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_node_get_fsm_time_median", 
+      "units": "microseconds", 
+      "description": mp+"_node_get_fsm_time_median"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",  
+      "name": mp+"_vnode_index_deletes_total", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_vnode_index_deletes_total"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_riak_kv_vnodeq_max", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_riak_kv_vnodeq_max"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_riak_kv_vnodeq_min", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_riak_kv_vnodeq_min"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_node_gets", 
+      "units": "gets", 
+      "description": mp+"_node_gets"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_riak_kv_vnodeq_median", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_riak_kv_vnodeq_median"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_postcommit_fail", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_postcommit_fail"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_riak_search_vnodeq_median", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_riak_search_vnodeq_median"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_sys_wordsize", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_sys_wordsize"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_riak_kv_vnodes_running", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_riak_kv_vnodes_running"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_node_put_fsm_time_95", 
+      "units": "microseconds", 
+      "description": mp+"_node_put_fsm_time_95",
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",  
+      "name": mp+"_rings_reconciled_total", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_rings_reconciled_total"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_rebalance_delay_min", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_rebalance_delay_min"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_node_put_fsm_time_99", 
+      "units": "microseconds", 
+      "description": mp+"_node_put_fsm_time_99",
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_ring_creation_size", 
+      "units": "vnodes", 
+      "description": mp+"_ring_creation_size"
+    }))
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",
+      "name": mp+"_cpu_avg1",
+      "format": "%u",
+      "value_type": "uint",
+      "units": "N",
+      "description": mp+"_cpu_avg1"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_cpu_avg5", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_cpu_avg5"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",  
+      "name": mp+"_pbc_connects_total", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_pbc_connects_total"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_memory_binary", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_memory_binary"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",  
+      "name": mp+"_coord_redirs_total", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_coord_redirs_total"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",  
+      "name": mp+"_riak_pipe_vnodeq_total", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_riak_pipe_vnodeq_total"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",  
+      "name": mp+"_node_gets_total", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_node_gets_total"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",  
+      "name": mp+"_vnode_puts_total", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_vnode_puts_total"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_memory_atom", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_memory_atom"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_cpu_avg15", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_cpu_avg15"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_node_get_fsm_objsize_median", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_node_get_fsm_objsize_median"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_node_get_fsm_siblings_mean", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_node_get_fsm_siblings_mean"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_converge_delay_min", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_converge_delay_min"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_node_get_fsm_time_100", 
+      "units": "microseconds", 
+      "description": mp+"_node_get_fsm_time_100"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_converge_delay_max", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_converge_delay_max"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_converge_delay_last", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_converge_delay_last"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_rebalance_delay_last", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_rebalance_delay_last"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_vnode_index_deletes", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_vnode_index_deletes"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "positive",  
+      "name": mp+"_riak_kv_vnodeq_total", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_riak_kv_vnodeq_total"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_handoff_timeouts", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_handoff_timeouts"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_vnode_index_reads", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_vnode_index_reads"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_sys_thread_pool_size", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_sys_thread_pool_size"
+    })) 
+    descriptors.append(create_desc(Desc_Skel, {
+      "slope": "both",  
+      "name": mp+"_pbc_connects", 
+      "format": "%u", 
+      "value_type": "uint",  
+      "units": "N", 
+      "description": mp+"_pbc_connects"
+    })) 
 
+    
     return descriptors
 
 def create_desc(skel, prop):
@@ -294,7 +1028,6 @@ if __name__ == '__main__':
             "debug" : True,
             }
         metric_init(params)
-
         while True:
             for d in descriptors:
                 v = d['call_back'](d['name'])

--- a/gmond/python_modules/disk/diskfree.py
+++ b/gmond/python_modules/disk/diskfree.py
@@ -34,11 +34,11 @@ import re
 import os
 
 # Minimum disk size
-MIN_DISK_SIZE=1
+MIN_DISK_SIZE = 1
 
 NAME_PREFIX = 'disk_free_'
 PARAMS = {
-    'mounts' : '/proc/mounts'
+    'mounts': '/proc/mounts'
 }
 PATHS = {}
 
@@ -62,7 +62,7 @@ def get_value(name):
         if unit_type == 'percent':
             result = (float(disk.f_bavail) / float(disk.f_blocks)) * 100
         else:
-            result = (disk.f_bavail * disk.f_frsize) / float(2**30) # GB
+            result = (disk.f_bavail * disk.f_frsize) / float(2**30)  # GB
 
     except OSError:
         result = 0
@@ -100,15 +100,15 @@ def metric_init(lparams):
                 path_key = 'rootfs'
             else:
                 path_key = mount_info[1][1:].replace('/', '_')
-                
+
             # Calculate the size of the disk. We'll use it exclude small disks
-            disk = os.statvfs(mount_info[1])            
+            disk = os.statvfs(mount_info[1])
             disk_size = (disk.f_blocks * disk.f_frsize) / float(2**30)
 
             if disk_size > MIN_DISK_SIZE and mount_info[1] != "/dev":
                 PATHS[path_key] = mount_info[1]
                 for unit_type in ['absolute', 'percent']:
-                    if unit_type == 'percent': 
+                    if unit_type == 'percent':
                         units = '%'
                     else:
                         units = 'GB'

--- a/gmond/python_modules/disk/diskfree.py
+++ b/gmond/python_modules/disk/diskfree.py
@@ -25,6 +25,11 @@
 # THE SOFTWARE.
 #
 
+# This module reads a list of mountpoints from the "mounts" parameter (probably
+# /proc/mounts) and creates a "disk_free_(absolute|percent)_*" metric for each
+# mountpoint it finds.
+
+
 import re
 import os
 

--- a/gmond/python_modules/disk/diskstat.py
+++ b/gmond/python_modules/disk/diskstat.py
@@ -27,6 +27,17 @@
 #    ignoring any devices present in IGNORE_DEV by default.
 #    [Can be overriden if "devices" is set]
 #
+#   Example  Metrics
+#    * diskstat_XXX_io_time
+#    * diskstat_XXX_read_kbytes_per_sec
+#    * diskstat_XXX_read_time
+#    * diskstat_XXX_reads
+#    * diskstat_XXX_reads_merged
+#    * diskstat_XXX_weighted_io_time
+#    * diskstat_XXX_write_kbytes_per_sec
+#    * diskstat_XXX_write_time
+#    * diskstat_XXX_writes
+#    * diskstat_XXX_writes_merged
 #  Changelog:
 #    v1.0.1 - 2010-07-22
 #       * Initial version

--- a/gmond/python_modules/disk/diskstat.py
+++ b/gmond/python_modules/disk/diskstat.py
@@ -183,7 +183,7 @@ def get_partitions():
     global PARTITIONS
 
     # We need DEVICES != "" because on at least Centos 6 this evaluates to true
-    if DEVICES is not None and DEVICES != "" :
+    if DEVICES is not None and DEVICES != "":
         # Explicit device list has been set
         logging.debug(' DEVICES has already been set')
         out = DEVICES

--- a/gmond/python_modules/example/example.py
+++ b/gmond/python_modules/example/example.py
@@ -35,13 +35,16 @@ descriptors = list()
 Random_Max = 50
 Constant_Value = 50
 
+
 def Random_Numbers(name):
     '''Return a random number.'''
     return int(random.uniform(0, Random_Max))
 
+
 def Constant_Number(name):
     '''Return a constant number.'''
     return int(Constant_Value)
+
 
 def metric_init(params):
     '''Initialize the random number generator and create the
@@ -81,9 +84,11 @@ def metric_init(params):
     descriptors = [d1, d2]
     return descriptors
 
+
 def metric_cleanup():
     '''Clean up the metric module.'''
     pass
+
 
 #This code is for debugging and unit testing
 if __name__ == '__main__':
@@ -92,5 +97,4 @@ if __name__ == '__main__':
     metric_init(params)
     for d in descriptors:
         v = d['call_back'](d['name'])
-        print 'value for %s is %u' % (d['name'],  v)
-
+        print 'value for %s is %u' % (d['name'], v)

--- a/gmond/python_modules/example/spfexample.py
+++ b/gmond/python_modules/example/spfexample.py
@@ -30,7 +30,8 @@
 #* Author: Brad Nicholes (bnicholes novell.com)
 #******************************************************************************/
 
-import random, time
+import random
+import time
 
 descriptors = list()
 
@@ -39,7 +40,7 @@ descriptors = list()
 #  module would be expected to discover spoofed hosts through
 #  some sort of query mechanism or by reading some type of
 #  input file.
-spoofHosts = [['spf1.myhost.org','10.10.0.1'], ['spf2.myhost.org','10.10.0.2'], ['spf3.myhost.org','10.10.0.3']]
+spoofHosts = [['spf1.myhost.org', '10.10.0.1'], ['spf2.myhost.org', '10.10.0.2'], ['spf3.myhost.org', '10.10.0.3']]
 
 # Default hardcoded metric values
 location = 'unspecified'
@@ -47,27 +48,33 @@ osname = 'SuSE Linux Ultimate'
 started = int(time.time())
 bootTime = {}
 
+
 def spf_heartbeat(name):
     '''Return heartbeat.'''
     return started
+
 
 def spf_location(name):
     '''Return location.'''
     return location
 
+
 def spf_boottime(name):
     '''Return boottime.'''
     return started
+
 
 def spf_osname(name):
     '''Return OS Name.'''
     return osname
 
+
 def Random_Numbers(name):
     '''Return a random number.'''
     return int(random.uniform(0, 100))
 
-def Init_Metric (spfHost, name, tmax, metrictype, units, slope, fmt, desc, metricAlias, ipAddr, handler):
+
+def Init_Metric(spfHost, name, tmax, metrictype, units, slope, fmt, desc, metricAlias, ipAddr, handler):
     '''Create a metric definition dictionary object for an imaginary box.'''
     metric_name = name + ':' + spfHost
     spoofHost = ipAddr + ':' + spfHost
@@ -79,7 +86,6 @@ def Init_Metric (spfHost, name, tmax, metrictype, units, slope, fmt, desc, metri
     # spoof_name - Must be the original name of the metric that this definition will be spoofing.
     #          In other words, if this metric name is spf_boottime, the spoof_name would be
     #          boottime if this metric is meant to spoof the original boottime metric.
-
 
     d = {'name': metric_name,
         'call_back': handler,
@@ -93,6 +99,7 @@ def Init_Metric (spfHost, name, tmax, metrictype, units, slope, fmt, desc, metri
         'spoof_name': metricAlias}
 
     return d
+
 
 def metric_init(params):
     '''Initialize the random number generator and create the
@@ -114,9 +121,11 @@ def metric_init(params):
 
     return descriptors
 
+
 def metric_cleanup():
     '''Clean up the metric module.'''
     pass
+
 
 #This code is for debugging and unit testing
 if __name__ == '__main__':
@@ -124,5 +133,5 @@ if __name__ == '__main__':
     d = metric_init(params)
     for d in descriptors:
         v = d['call_back'](d['name'])
-        print 'value for %s is %s' % (d['name'],  str(v))
-    print  d
+        print 'value for %s is %s' % (d['name'], str(v))
+    print d

--- a/gmond/python_modules/memcached/memcached.py
+++ b/gmond/python_modules/memcached/memcached.py
@@ -11,14 +11,16 @@ import select
 import errno
 
 descriptors = list()
-Desc_Skel   = {}
+Desc_Skel = {}
 _Worker_Thread = None
-_Lock = threading.Lock() # synchronization lock
+_Lock = threading.Lock()  # synchronization lock
 Debug = False
+
 
 def dprint(f, *v):
     if Debug:
-        print >>sys.stderr, "DEBUG: "+f % v
+        print >>sys.stderr, "DEBUG: " + f % v
+
 
 def floatable(str):
     try:
@@ -27,27 +29,28 @@ def floatable(str):
     except:
         return False
 
+
 class UpdateMetricThread(threading.Thread):
 
     def __init__(self, params):
         threading.Thread.__init__(self)
-        self.running      = False
+        self.running = False
         self.shuttingdown = False
         self.refresh_rate = 15
         if "refresh_rate" in params:
             self.refresh_rate = int(params["refresh_rate"])
-        self.metric       = {}
-        self.last_metric       = {}
-        self.timeout      = 2
+        self.metric = {}
+        self.last_metric = {}
+        self.timeout = 2
 
-        self.host         = "localhost"
-        self.port         = 11211
+        self.host = "localhost"
+        self.port = 11211
         if "host" in params:
             self.host = params["host"]
         if "port" in params:
             self.port = int(params["port"])
-        self.type    = params["type"]
-        self.mp      = params["metrix_prefix"]
+        self.type = params["type"]
+        self.mp = params["metrix_prefix"]
 
     def shutdown(self):
         self.shuttingdown = True
@@ -71,7 +74,7 @@ class UpdateMetricThread(threading.Thread):
 
     def update_metric(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        msg  = ""
+        msg = ""
         self.last_metric = self.metric.copy()
         try:
             dprint("connect %s:%d", self.host, self.port)
@@ -108,19 +111,19 @@ class UpdateMetricThread(threading.Thread):
         for m in msg.split("\r\n"):
             d = m.split(" ")
             if len(d) == 3 and d[0] == "STAT" and floatable(d[2]):
-                self.metric[self.mp+"_"+d[1]] = float(d[2])
+                self.metric[self.mp + "_" + d[1]] = float(d[2])
 
     def metric_of(self, name):
         val = 0
         mp = name.split("_")[0]
-        if name.rsplit("_",1)[1] == "rate" and name.rsplit("_",1)[0] in self.metric:
+        if name.rsplit("_", 1)[1] == "rate" and name.rsplit("_", 1)[0] in self.metric:
             _Lock.acquire()
-            name = name.rsplit("_",1)[0]
+            name = name.rsplit("_", 1)[0]
             if name in self.last_metric:
-                num = self.metric[name]-self.last_metric[name]
-                period = self.metric[mp+"_time"]-self.last_metric[mp+"_time"]
+                num = self.metric[name] - self.last_metric[name]
+                period = self.metric[mp + "_time"] - self.last_metric[mp + "_time"]
                 try:
-                    val = num/period
+                    val = num / period
                 except ZeroDivisionError:
                     val = 0
             _Lock.release()
@@ -132,6 +135,7 @@ class UpdateMetricThread(threading.Thread):
         if val < 0:
             val = 0
         return val
+
 
 def metric_init(params):
     global descriptors, Desc_Skel, _Worker_Thread, Debug
@@ -156,7 +160,7 @@ def metric_init(params):
         'value_type'  : 'float',
         'format'      : '%.0f',
         'units'       : 'XXX',
-        'slope'       : 'XXX', # zero|positive|negative|both
+        'slope'       : 'XXX',  # zero|positive|negative|both
         'description' : 'XXX',
         'groups'      : params["type"],
         }
@@ -177,127 +181,127 @@ def metric_init(params):
     mp = params["metrix_prefix"]
 
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_curr_items",
+                "name"       : mp + "_curr_items",
                 "units"      : "items",
                 "slope"      : "both",
                 "description": "Current number of items stored",
                 }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_cmd_get",
+                "name"       : mp + "_cmd_get",
                 "units"      : "commands",
                 "slope"      : "positive",
                 "description": "Cumulative number of retrieval reqs",
                 }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_cmd_set",
+                "name"       : mp + "_cmd_set",
                 "units"      : "commands",
                 "slope"      : "positive",
                 "description": "Cumulative number of storage reqs",
                 }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_bytes_read",
+                "name"       : mp + "_bytes_read",
                 "units"      : "bytes",
                 "slope"      : "positive",
                 "description": "Total number of bytes read by this server from network",
                 }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_bytes_written",
+                "name"       : mp + "_bytes_written",
                 "units"      : "bytes",
                 "slope"      : "positive",
                 "description": "Total number of bytes sent by this server to network",
                 }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_bytes",
+                "name"       : mp + "_bytes",
                 "units"      : "bytes",
                 "slope"      : "both",
                 "description": "Current number of bytes used to store items",
                 }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_limit_maxbytes",
+                "name"       : mp + "_limit_maxbytes",
                 "units"      : "bytes",
                 "slope"      : "both",
                 "description": "Number of bytes this server is allowed to use for storage",
                 }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_curr_connections",
+                "name"       : mp + "_curr_connections",
                 "units"      : "connections",
                 "slope"      : "both",
                 "description": "Number of open connections",
                 }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_decr_hits",
+                "name"       : mp + "_decr_hits",
                 "units"      : "items",
                 "slope"      : "positive",
                 "description": "Number of keys that have been decremented and found present ",
                 }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_decr_misses",
+                "name"       : mp + "_decr_misses",
                 "units"      : "items",
                 "slope"      : "positive",
                 "description": "Number of items that have been decremented and not found",
                 }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_delete_hits",
+                "name"       : mp + "_delete_hits",
                 "units"      : "items",
                 "slope"      : "positive",
                 "description": "Number of keys that have been deleted and found present ",
                 }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_delete_misses",
+                "name"       : mp + "_delete_misses",
                 "units"      : "items",
                 "slope"      : "positive",
                 "description": "Number of items that have been deleted and not found",
                 }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_evictions",
+                "name"       : mp + "_evictions",
                 "units"      : "items",
                 "slope"      : "both",
                 "description": "Number of valid items removed from cache to free memory for new items",
                 }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_get_hits",
+                "name"       : mp + "_get_hits",
                 "units"      : "items",
                 "slope"      : "positive",
                 "description": "Number of keys that have been requested and found present ",
                 }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_get_misses",
+                "name"       : mp + "_get_misses",
                 "units"      : "items",
                 "slope"      : "positive",
                 "description": "Number of items that have been requested and not found",
                 }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_get_hits_rate",
+                "name"       : mp + "_get_hits_rate",
                 "units"      : "items",
                 "slope"      : "both",
                 "description": "Hits per second",
                 }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_get_misses_rate",
+                "name"       : mp + "_get_misses_rate",
                 "units"      : "items",
                 "slope"      : "both",
                 "description": "Misses per second",
                 }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_incr_hits",
+                "name"       : mp + "_incr_hits",
                 "units"      : "items",
                 "slope"      : "positive",
                 "description": "Number of keys that have been incremented and found present ",
                 }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_incr_misses",
+                "name"       : mp + "_incr_misses",
                 "units"      : "items",
                 "slope"      : "positive",
                 "description": "Number of items that have been incremented and not found",
                 }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_cmd_get_rate",
+                "name"       : mp + "_cmd_get_rate",
                 "units"      : "commands",
                 "slope"      : "both",
                 "description": "Gets per second",
                 }))
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : mp+"_cmd_set_rate",
+                "name"       : mp + "_cmd_set_rate",
                 "units"      : "commands",
                 "slope"      : "both",
                 "description": "Sets per second",
@@ -308,65 +312,68 @@ def metric_init(params):
         dtmp = descriptors[:]
         for d in dtmp:
             if d["name"] in [
-                mp+"_bytes_read",
-                mp+"_bytes_written",
-                mp+"_limit_maxbytes",
-                mp+"_curr_connections",
-                mp+"_evictions",
+                mp + "_bytes_read",
+                mp + "_bytes_written",
+                mp + "_limit_maxbytes",
+                mp + "_curr_connections",
+                mp + "_evictions",
                 ]:
                 descriptors.remove(d)
         for d in descriptors:
-            if d["name"] == mp+"_get_hits":
-                d["name"] = mp+"_cmd_get_hits"
-            if d["name"] == mp+"_get_misses":
-                d["name"] = mp+"_cmd_get_misses"
+            if d["name"] == mp + "_get_hits":
+                d["name"] = mp + "_cmd_get_hits"
+            if d["name"] == mp + "_get_misses":
+                d["name"] = mp + "_cmd_get_misses"
 
         descriptors.append(create_desc(Desc_Skel, {
-                    "name"       : mp+"_cmd_set_hits",
+                    "name"       : mp + "_cmd_set_hits",
                     "units"      : "items",
                     "slope"      : "positive",
                     "description": "Number of keys that have been stored and found present ",
                     }))
         descriptors.append(create_desc(Desc_Skel, {
-                    "name"       : mp+"_cmd_set_misses",
+                    "name"       : mp + "_cmd_set_misses",
                     "units"      : "items",
                     "slope"      : "positive",
                     "description": "Number of items that have been stored and not found",
                     }))
 
         descriptors.append(create_desc(Desc_Skel, {
-                    "name"       : mp+"_cmd_delete",
+                    "name"       : mp + "_cmd_delete",
                     "units"      : "commands",
                     "slope"      : "positive",
                     "description": "Cumulative number of delete reqs",
                     }))
         descriptors.append(create_desc(Desc_Skel, {
-                    "name"       : mp+"_cmd_delete_hits",
+                    "name"       : mp + "_cmd_delete_hits",
                     "units"      : "items",
                     "slope"      : "positive",
                     "description": "Number of keys that have been deleted and found present ",
                     }))
         descriptors.append(create_desc(Desc_Skel, {
-                    "name"       : mp+"_cmd_delete_misses",
+                    "name"       : mp + "_cmd_delete_misses",
                     "units"      : "items",
                     "slope"      : "positive",
                     "description": "Number of items that have been deleted and not found",
                     }))
 
-
     return descriptors
+
 
 def create_desc(skel, prop):
     d = skel.copy()
-    for k,v in prop.iteritems():
+    for k, v in prop.iteritems():
         d[k] = v
     return d
+
 
 def metric_of(name):
     return _Worker_Thread.metric_of(name)
 
+
 def metric_cleanup():
     _Worker_Thread.shutdown()
+
 
 if __name__ == '__main__':
     try:
@@ -384,7 +391,7 @@ if __name__ == '__main__':
         while True:
             for d in descriptors:
                 v = d['call_back'](d['name'])
-                print ('value for %s is '+d['format']) % (d['name'],  v)
+                print ('value for %s is ' + d['format']) % (d['name'], v)
             time.sleep(5)
     except KeyboardInterrupt:
         time.sleep(0.2)

--- a/gmond/python_modules/memory/mem_stats.py
+++ b/gmond/python_modules/memory/mem_stats.py
@@ -16,7 +16,8 @@ import re
 
 meminfo_file = "/proc/meminfo"
 
-def metrics_handler(name):  
+
+def metrics_handler(name):
     try:
         file = open(meminfo_file, 'r')
 
@@ -25,22 +26,24 @@ def metrics_handler(name):
 
     value = 0
     for line in file:
-	parts = re.split("\s+", line)
-	if parts[0] == metric_map[name]['name'] + ":" :
-	    # All of the measurements are in kBytes. We want to change them over
-	    # to Bytes
-	    if metric_map[name]['units'] == "Bytes":
-		value = float(parts[1]) * 1024
-	    else:
+        parts = re.split("\s+", line)
+        if parts[0] == metric_map[name]['name'] + ":":
+            # All of the measurements are in kBytes. We want to change them over
+            # to Bytes
+            if metric_map[name]['units'] == "Bytes":
+                value = float(parts[1]) * 1024
+            else:
                 value = parts[1]
-	
+
     return float(value)
+
 
 def create_desc(skel, prop):
     d = skel.copy()
-    for k,v in prop.iteritems():
+    for k, v in prop.iteritems():
         d[k] = v
     return d
+
 
 def metric_init(params):
     global descriptors, metric_map, Desc_Skel
@@ -55,7 +58,7 @@ def metric_init(params):
         'value_type'  : 'float',
         'format'      : '%.0f',
         'units'       : 'XXX',
-        'slope'       : 'both', # zero|positive|negative|both
+        'slope'       : 'both',  # zero|positive|negative|both
         'description' : 'XXX',
         'groups'      : 'memory',
         }
@@ -349,20 +352,22 @@ def metric_init(params):
 
     # We need a metric_map that maps metric_name to the index in /proc/meminfo
     metric_map = {}
-    
+
     for d in descriptors:
-	metric_name = d['name']
-        metric_map[metric_name] = { "name": d['orig_name'], "units": d['units'] }
-        
+        metric_name = d['name']
+        metric_map[metric_name] = {"name": d['orig_name'], "units": d['units']}
+
     return descriptors
+
 
 def metric_cleanup():
     '''Clean up the metric module.'''
     pass
 
-#This code is for debugging and unit testing
+
+# This code is for debugging and unit testing
 if __name__ == '__main__':
     metric_init({})
     for d in descriptors:
         v = d['call_back'](d['name'])
-        print 'value for %s is %f' % (d['name'],  v)
+        print 'value for %s is %f' % (d['name'], v)

--- a/gmond/python_modules/memory/mem_stats.py
+++ b/gmond/python_modules/memory/mem_stats.py
@@ -110,7 +110,7 @@ def metric_init(params):
                 }))
 
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : "mem_total",
+                "name"       : "mem_total_anon",
                 "orig_name"  : "Active(anon)",
                 "units"      : "Bytes",
                 "description": "Active(anon)",

--- a/gmond/python_modules/network/multi_interface.py
+++ b/gmond/python_modules/network/multi_interface.py
@@ -1,3 +1,44 @@
+# This module allows you to collect per network interface network stats. Out
+# of the box Ganglia provides only aggregate network metrics. This module will
+# give you rx (receive) and tx (transmit) stats for every interface it encounters
+# e.g.
+
+# value for rx_bytes_lo is 21847.3723
+# value for rx_pkts_lo is 17.5771
+# value for rx_errs_lo is 0.0000
+# value for rx_drops_lo is 0.0000
+# value for tx_bytes_lo is 21847.3723
+# value for tx_pkts_lo is 17.5771
+# value for tx_errs_lo is 0.0000
+# value for tx_drops_lo is 0.0000
+# value for rx_bytes_eth0 is 0.0000
+# value for rx_pkts_eth0 is 0.0000
+# value for rx_errs_eth0 is 0.0000
+# value for rx_drops_eth0 is 0.0000
+# value for tx_bytes_eth0 is 0.0000
+# value for tx_pkts_eth0 is 0.0000
+# value for tx_errs_eth0 is 0.0000
+# value for tx_drops_eth0 is 0.0000
+# value for rx_bytes_eth1 is 0.0000
+# value for rx_pkts_eth1 is 0.0000
+# value for rx_errs_eth1 is 0.0000
+# value for rx_drops_eth1 is 0.0000
+# value for tx_bytes_eth1 is 0.0000
+# value for tx_pkts_eth1 is 0.0000
+# value for tx_errs_eth1 is 0.0000
+# value for tx_drops_eth1 is 0.0000
+
+# You can run the multi_interface.py script by hand to see all of the metrics.
+
+# In addition this script can be used to override "default" bytes_in, bytes_out, pkts_in and pkts_out
+# metrics. To do that you will need to 
+
+# * set send_aggregate_bytes_packets to True in multi_interface.pyconf
+# * Uncomment bytes_in, bytes_out metrics to be sent in in multi_interface.pyconf
+# * Comment out those same metrics you uncommented in step above in gmond.conf so they don't override 
+#  each other
+
+
 import re
 import time
 import sys

--- a/gmond/python_modules/network/multi_interface.py
+++ b/gmond/python_modules/network/multi_interface.py
@@ -31,11 +31,11 @@
 # You can run the multi_interface.py script by hand to see all of the metrics.
 
 # In addition this script can be used to override "default" bytes_in, bytes_out, pkts_in and pkts_out
-# metrics. To do that you will need to 
+# metrics. To do that you will need to
 
 # * set send_aggregate_bytes_packets to True in multi_interface.pyconf
 # * Uncomment bytes_in, bytes_out metrics to be sent in in multi_interface.pyconf
-# * Comment out those same metrics you uncommented in step above in gmond.conf so they don't override 
+# * Comment out those same metrics you uncommented in step above in gmond.conf so they don't override
 #  each other
 
 
@@ -48,8 +48,8 @@ import copy
 PARAMS = {}
 
 METRICS = {
-    'time' : 0,
-    'data' : {}
+    'time': 0,
+    'data': {}
 }
 LAST_METRICS = copy.deepcopy(METRICS)
 METRICS_CACHE_MAX = 5
@@ -58,35 +58,37 @@ INTERFACES = []
 descriptors = []
 
 stats_tab = {
-    "rx_bytes"  : 0,
-    "rx_pkts"   : 1,
-    "rx_errs"   : 2,
-    "rx_drops"  : 3,
-    "tx_bytes" : 8,
-    "tx_pkts"  : 9,
-    "tx_errs"  : 10,
-    "tx_drops" : 11,
+    "rx_bytes": 0,
+    "rx_pkts": 1,
+    "rx_errs": 2,
+    "rx_drops": 3,
+    "tx_bytes": 8,
+    "tx_pkts": 9,
+    "tx_errs": 10,
+    "tx_drops": 11,
 }
 
 # Where to get the stats from
 net_stats_file = "/proc/net/dev"
 
+
 def create_desc(skel, prop):
     d = skel.copy()
-    for k,v in prop.iteritems():
+    for k, v in prop.iteritems():
         d[k] = v
     return d
+
 
 def metric_init(params):
     global descriptors
     global INTERFACES
-    
-#    INTERFACES = params.get('interfaces')
+
+    # INTERFACES = params.get('interfaces')
     watch_interfaces = params.get('interfaces')
     excluded_interfaces = params.get('excluded_interfaces')
     get_interfaces(watch_interfaces,excluded_interfaces)
 
-#    print INTERFACES
+    # print INTERFACES
     time_max = 60
 
     Desc_Skel = {
@@ -96,11 +98,10 @@ def metric_init(params):
         'value_type'  : 'float',
         'format'      : '%.0f',
         'units'       : '/s',
-        'slope'       : 'both', # zero|positive|negative|both
+        'slope'       : 'both',  # zero|positive|negative|both
         'description' : 'XXX',
         'groups'      : 'network',
         }
-
 
     for dev in INTERFACES:
         descriptors.append(create_desc(Desc_Skel, {
@@ -123,7 +124,7 @@ def metric_init(params):
                     "units"       : "pkts/sec",
                     "description" : "receive packets dropped per sec",
                     }))
-    
+
         descriptors.append(create_desc(Desc_Skel, {
                     "name"        : "tx_bytes_" + dev,
                     "units"       : "bytes/sec",
@@ -173,39 +174,43 @@ def metric_init(params):
 
     return descriptors
 
+
 def metric_cleanup():
     '''Clean up the metric module.'''
     pass
-    
+
+
 ###################################################################################
 # Build a list of interfaces
-###################################################################################    
-def get_interfaces(watch_interfaces, excluded_interfaces):
-   global INTERFACES
-   if_excluded = 0
-        
-   # check if particular interfaces have been specifieid. Watch only those
-   if watch_interfaces != "":
-      INTERFACES = watch_interfaces.split(" ")      
-   else:
-      if excluded_interfaces != "":
-         excluded_if_list = excluded_interfaces.split(" ")
-      f = open(net_stats_file, "r")
-      for line in f:
-         # Find only lines with :
-         if re.search(":", line):
-            a = line.split(":")
-            dev_name = a[0].lstrip()
-                    
-            # Determine if interface is excluded by name or regex
-            for ex in excluded_if_list:
-               if re.match(ex,dev_name):
-                  if_excluded = 1
+###################################################################################
 
-            if not if_excluded:
-               INTERFACES.append(dev_name)
-            if_excluded = 0
-   return 0
+
+def get_interfaces(watch_interfaces, excluded_interfaces):
+    global INTERFACES
+    if_excluded = 0
+
+    # check if particular interfaces have been specifieid. Watch only those
+    if watch_interfaces != "":
+        INTERFACES = watch_interfaces.split(" ")
+    else:
+        if excluded_interfaces != "":
+            excluded_if_list = excluded_interfaces.split(" ")
+        f = open(net_stats_file, "r")
+        for line in f:
+            # Find only lines with :
+            if re.search(":", line):
+                a = line.split(":")
+                dev_name = a[0].lstrip()
+
+                # Determine if interface is excluded by name or regex
+                for ex in excluded_if_list:
+                    if re.match(ex, dev_name):
+                        if_excluded = 1
+
+                if not if_excluded:
+                    INTERFACES.append(dev_name)
+                if_excluded = 0
+    return 0
 
 
 ###################################################################################
@@ -217,36 +222,34 @@ def get_aggregates(name):
 
     # get metrics
     [curr_metrics, last_metrics] = get_metrics()
-    
+
     # Determine the index of metric we need
     if name == "bytes_in":
-      index = stats_tab["rx_bytes"]
+        index = stats_tab["rx_bytes"]
     elif name == "bytes_out":
-      index = stats_tab["tx_bytes"]
+        index = stats_tab["tx_bytes"]
     elif name == "pkts_out":
-      index = stats_tab["tx_pkts"]
+        index = stats_tab["tx_pkts"]
     elif name == "pkts_in":
-      index = stats_tab["rx_pkts"]
+        index = stats_tab["rx_pkts"]
     else:
-      return 0
+        return 0
 
     sum = 0
-    
+
     # Loop through the list of interfaces we care for
     for iface in INTERFACES:
-      
-      try:
-	delta = (float(curr_metrics['data'][iface][index]) - float(last_metrics['data'][iface][index])) /(curr_metrics['time'] - last_metrics['time'])
-	if delta < 0:
-	  print name + " is less 0"
-	  delta = 0
-      except KeyError:
-	delta = 0.0      
-    
-      sum += delta
+        try:
+            delta = (float(curr_metrics['data'][iface][index]) - float(last_metrics['data'][iface][index])) / (curr_metrics['time'] - last_metrics['time'])
+            if delta < 0:
+                print name + " is less 0"
+                delta = 0
+        except KeyError:
+            delta = 0.0
+
+    sum += delta
 
     return sum
-
 
 
 def get_metrics():
@@ -256,11 +259,11 @@ def get_metrics():
 
     if (time.time() - METRICS['time']) > METRICS_CACHE_MAX:
 
-	try:
-	    file = open(net_stats_file, 'r')
-    
-	except IOError:
-	    return 0
+        try:
+            file = open(net_stats_file, 'r')
+
+        except IOError:
+            return 0
 
         # convert to dict
         metrics = {}
@@ -278,7 +281,8 @@ def get_metrics():
         }
 
     return [METRICS, LAST_METRICS]
-    
+
+
 def get_delta(name):
     """Return change over time for the requested metric"""
 
@@ -294,12 +298,12 @@ def get_delta(name):
     index = stats_tab[name]
 
     try:
-      delta = (float(curr_metrics['data'][iface][index]) - float(last_metrics['data'][iface][index])) /(curr_metrics['time'] - last_metrics['time'])
-      if delta < 0:
-	print name + " is less 0"
-	delta = 0
+        delta = (float(curr_metrics['data'][iface][index]) - float(last_metrics['data'][iface][index])) / (curr_metrics['time'] - last_metrics['time'])
+        if delta < 0:
+            print name + " is less 0"
+            delta = 0
     except KeyError:
-      delta = 0.0      
+        delta = 0.0
 
     return delta
 
@@ -310,13 +314,13 @@ if __name__ == '__main__':
             "interfaces": "",
             "excluded_interfaces": "dummy",
             "send_aggregate_bytes_packets": True,
-            "debug"        : True,
+            "debug": True,
             }
         metric_init(params)
         while True:
             for d in descriptors:
                 v = d['call_back'](d['name'])
-                print ('value for %s is '+d['format']) % (d['name'],  v)
+                print ('value for %s is ' + d['format']) % (d['name'],  v)
             time.sleep(5)
     except StandardError:
         print sys.exc_info()[0]

--- a/gmond/python_modules/network/netstats.py
+++ b/gmond/python_modules/network/netstats.py
@@ -11,16 +11,17 @@ import string
 PARAMS = {}
 
 METRICS = {
-    'time' : 0,
-    'data' : {}
+    'time': 0,
+    'data': {}
 }
 
-stats_files = [ "/proc/net/netstat", "/proc/net/snmp" ]
+stats_files = ["/proc/net/netstat", "/proc/net/snmp"]
 
 LAST_METRICS = copy.deepcopy(METRICS)
 METRICS_CACHE_MAX = 5
 
-stats_pos = {} 
+stats_pos = {}
+
 
 def get_metrics():
     """Return all metrics"""
@@ -29,31 +30,31 @@ def get_metrics():
 
     if (time.time() - METRICS['time']) > METRICS_CACHE_MAX:
 
-	new_metrics = {}
+        new_metrics = {}
 
-	for file in stats_files:
-	    try:
-		file = open(file, 'r')
-	
-	    except IOError:
-		return 0
-    
-	    # convert to dict
-	    metrics = {}
-	    for line in file:
-		if re.match("(.*): [0-9]", line):
-		    count = 0
-		    metrics = re.split("\s+", line)
-		    metric_group = metrics[0].replace(":", "").lower()
-		    new_metrics[metric_group] = dict()
-		    for value in metrics:
-			# Skip first
-			if count > 0 and value >= 0 and count in stats_pos[metric_group]:
-			    metric_name = stats_pos[metric_group][count]
-			    new_metrics[metric_group][metric_name] = value
-			count += 1
+        for file in stats_files:
+            try:
+                file = open(file, 'r')
 
-	    file.close()
+            except IOError:
+                return 0
+
+            # convert to dict
+            metrics = {}
+            for line in file:
+                if re.match("(.*): [0-9]", line):
+                    count = 0
+                    metrics = re.split("\s+", line)
+                    metric_group = metrics[0].replace(":", "").lower()
+                    new_metrics[metric_group] = dict()
+                    for value in metrics:
+                        # Skip first
+                        if count > 0 and value >= 0 and count in stats_pos[metric_group]:
+                            metric_name = stats_pos[metric_group][count]
+                            new_metrics[metric_group][metric_name] = value
+                        count += 1
+
+            file.close()
 
         # update cache
         LAST_METRICS = copy.deepcopy(METRICS)
@@ -70,7 +71,7 @@ def get_value(name):
 
     metrics = get_metrics()[0]
 
-    name = name[len(NAME_PREFIX):] # remove prefix from name
+    name = name[len(NAME_PREFIX):]  # remove prefix from name
 
     try:
         result = metrics['data'][name]
@@ -91,12 +92,12 @@ def get_delta(name):
     metric = "_".join(parts[1:])
 
     try:
-      delta = (float(curr_metrics['data'][group][metric]) - float(last_metrics['data'][group][metric])) /(curr_metrics['time'] - last_metrics['time'])
-      if delta < 0:
-	print name + " is less 0"
-	delta = 0
+        delta = (float(curr_metrics['data'][group][metric]) - float(last_metrics['data'][group][metric])) / (curr_metrics['time'] - last_metrics['time'])
+        if delta < 0:
+            print name + " is less 0"
+            delta = 0
     except KeyError:
-      delta = 0.0      
+        delta = 0.0
 
     return delta
 
@@ -107,17 +108,17 @@ def get_tcploss_percentage(name):
     [curr_metrics, last_metrics] = get_metrics()
 
     try:
-      pct = 100 * (float(curr_metrics['data']['tcpext']["tcploss"]) - float(last_metrics["data"]['tcpext']["tcploss"])) / (float(curr_metrics['data']['tcp']['outsegs']) +  float(curr_metrics['data']['tcp']['insegs']) - float(last_metrics['data']['tcp']['insegs']) - float(last_metrics['data']['tcp']['outsegs']))
-      if pct < 0:
-	print name + " is less 0"
-	pct = 0
+        pct = 100 * (float(curr_metrics['data']['tcpext']["tcploss"]) - float(last_metrics["data"]['tcpext']["tcploss"])) / (float(curr_metrics['data']['tcp']['outsegs']) + float(curr_metrics['data']['tcp']['insegs']) - float(last_metrics['data']['tcp']['insegs']) - float(last_metrics['data']['tcp']['outsegs']))
+        if pct < 0:
+            print name + " is less 0"
+            pct = 0
     except KeyError:
-      pct = 0.0
+        pct = 0.0
     except ZeroDivisionError:
-      pct = 0.0
-
+        pct = 0.0
 
     return pct
+
 
 def get_tcpattemptfail_percentage(name):
 
@@ -125,12 +126,12 @@ def get_tcpattemptfail_percentage(name):
     [curr_metrics, last_metrics] = get_metrics()
 
     try:
-      pct = 100 * (float(curr_metrics['data']['tcp']["attemptfails"]) - float(last_metrics["data"]['tcp']["attemptfails"])) / (float(curr_metrics['data']['tcp']['outsegs']) +  float(curr_metrics['data']['tcp']['insegs']) - float(last_metrics['data']['tcp']['insegs']) - float(last_metrics['data']['tcp']['outsegs']))
-      if pct < 0:
-	print name + " is less 0"
-	pct = 0
+        pct = 100 * (float(curr_metrics['data']['tcp']["attemptfails"]) - float(last_metrics["data"]['tcp']["attemptfails"])) / (float(curr_metrics['data']['tcp']['outsegs']) + float(curr_metrics['data']['tcp']['insegs']) - float(last_metrics['data']['tcp']['insegs']) - float(last_metrics['data']['tcp']['outsegs']))
+        if pct < 0:
+            print name + " is less 0"
+            pct = 0
     except Exception:
-      pct = 0.0
+        pct = 0.0
 
     return pct
 
@@ -141,23 +142,24 @@ def get_retrans_percentage(name):
     [curr_metrics, last_metrics] = get_metrics()
 
     try:
-      pct = 100 * (float(curr_metrics['data']['tcp']["retranssegs"]) - float(last_metrics['data']['tcp']["retranssegs"])) / (float(curr_metrics['data']['tcp']['outsegs']) +  float(curr_metrics['data']['tcp']['insegs']) - float(last_metrics['data']['tcp']['insegs']) - float(last_metrics['data']['tcp']['outsegs']))
-      if pct < 0:
-	print name + " is less 0"
-	pct = 0
+        pct = 100 * (float(curr_metrics['data']['tcp']["retranssegs"]) - float(last_metrics['data']['tcp']["retranssegs"])) / (float(curr_metrics['data']['tcp']['outsegs']) + float(curr_metrics['data']['tcp']['insegs']) - float(last_metrics['data']['tcp']['insegs']) - float(last_metrics['data']['tcp']['outsegs']))
+        if pct < 0:
+            print name + " is less 0"
+            pct = 0
     except KeyError:
-      pct = 0.0
+        pct = 0.0
     except ZeroDivisionError:
-      pct = 0.0
+        pct = 0.0
 
     return pct
 
 
 def create_desc(skel, prop):
     d = skel.copy()
-    for k,v in prop.iteritems():
+    for k, v in prop.iteritems():
         d[k] = v
     return d
+
 
 def metric_init(params):
     global descriptors, metric_map, Desc_Skel
@@ -171,7 +173,7 @@ def metric_init(params):
         'value_type'  : 'float',
         'format'      : '%.5f',
         'units'       : 'count/s',
-        'slope'       : 'both', # zero|positive|negative|both
+        'slope'       : 'both',  # zero|positive|negative|both
         'description' : 'XXX',
         'groups'      : 'XXX',
         }
@@ -182,67 +184,68 @@ def metric_init(params):
     # Read /proc/net/netstat
     ####################################################################################
     for file in stats_files:
-	try:
-	    file = open(file, 'r')
-    
-	except IOError:
-	    return 0
-	
-	# Find mapping
-	for line in file:
-	    # Lines with 
-	    if not re.match("(.*): [0-9]", line):
-		count = 0
-		mapping = re.split("\s+", line)
-		metric_group = mapping[0].replace(":", "").lower()
-		stats_pos[metric_group] = dict()
-		for metric in mapping:
-		    # Skip first 
-		    if count > 0 and metric != "":
-			lowercase_metric = metric.lower()
-			stats_pos[metric_group][count] = lowercase_metric
-		    count += 1
-    
-	file.close()
+        try:
+            file = open(file, 'r')
+
+        except IOError:
+            return 0
+
+        # Find mapping
+        for line in file:
+            # Lines with
+            if not re.match("(.*): [0-9]", line):
+                count = 0
+                mapping = re.split("\s+", line)
+                metric_group = mapping[0].replace(":", "").lower()
+                stats_pos[metric_group] = dict()
+                for metric in mapping:
+                    # Skip first
+                    if count > 0 and metric != "":
+                        lowercase_metric = metric.lower()
+                        stats_pos[metric_group][count] = lowercase_metric
+                    count += 1
+
+        file.close()
 
     for group in stats_pos:
-	for item in stats_pos[group]:
-	    descriptors.append(create_desc(Desc_Skel, {
-		    "name"       : group + "_" + stats_pos[group][item],
-		    "description": stats_pos[group][item],
-		    'groups'	 : group
-		    }))
+        for item in stats_pos[group]:
+            descriptors.append(create_desc(Desc_Skel, {
+                    "name"       : group + "_" + stats_pos[group][item],
+                    "description": stats_pos[group][item],
+                    'groups'     : group
+                    }))
 
     descriptors.append(create_desc(Desc_Skel, {
-	"name"       : "tcpext_tcploss_percentage",
-	"call_back"  : get_tcploss_percentage,
-	"description": "TCP percentage loss, tcploss / insegs + outsegs",
-	"units"      : "pct",
+        "name"       : "tcpext_tcploss_percentage",
+        "call_back"  : get_tcploss_percentage,
+        "description": "TCP percentage loss, tcploss / insegs + outsegs",
+        "units"      : "pct",
         'groups'      : 'tcpext'
-	}))
+        }))
 
     descriptors.append(create_desc(Desc_Skel, {
-	"name"       : "tcp_attemptfails_percentage",
-	"call_back"  : get_tcpattemptfail_percentage,
-	"description": "TCP attemptfail percentage, tcpattemptfail / insegs + outsegs",
-	"units"      : "pct",
+        "name"       : "tcp_attemptfails_percentage",
+        "call_back"  : get_tcpattemptfail_percentage,
+        "description": "TCP attemptfail percentage, tcpattemptfail / insegs + outsegs",
+        "units"      : "pct",
         'groups'      : 'tcp'
-	}))
-
+        }))
 
     descriptors.append(create_desc(Desc_Skel, {
-	"name"       : "tcp_retrans_percentage",
-	"call_back"  : get_retrans_percentage,
-	"description": "TCP retrans percentage, retranssegs / insegs + outsegs",
-	"units"      : "pct",
+        "name"       : "tcp_retrans_percentage",
+        "call_back"  : get_retrans_percentage,
+        "description": "TCP retrans percentage, retranssegs / insegs + outsegs",
+        "units"      : "pct",
         'groups'      : 'tcp'
-	}))
+        }))
 
     return descriptors
+
 
 def metric_cleanup():
     '''Clean up the metric module.'''
     pass
+
 
 #This code is for debugging and unit testing
 if __name__ == '__main__':

--- a/gmond/python_modules/network/netstats.py
+++ b/gmond/python_modules/network/netstats.py
@@ -112,7 +112,24 @@ def get_tcploss_percentage(name):
     except ZeroDivisionError:
       pct = 0.0
 
+
     return pct
+
+def get_tcpattemptfail_percentage(name):
+
+    # get metrics
+    [curr_metrics, last_metrics] = get_metrics()
+
+    try:
+      pct = 100 * (float(curr_metrics['data']['tcp']["attemptfails"]) - float(last_metrics["data"]['tcp']["attemptfails"])) / (float(curr_metrics['data']['tcp']['outsegs']) +  float(curr_metrics['data']['tcp']['insegs']) - float(last_metrics['data']['tcp']['insegs']) - float(last_metrics['data']['tcp']['outsegs']))
+      if pct < 0:
+	print name + " is less 0"
+	pct = 0
+    except Exception:
+      pct = 0.0
+
+    return pct
+
 
 def get_retrans_percentage(name):
 
@@ -193,7 +210,7 @@ def metric_init(params):
 		    }))
 
     descriptors.append(create_desc(Desc_Skel, {
-	"name"       : "tcpext_" + "tcploss_percentage",
+	"name"       : "tcpext_tcploss_percentage",
 	"call_back"  : get_tcploss_percentage,
 	"description": "TCP percentage loss, tcploss / insegs + outsegs",
 	"units"      : "pct",
@@ -201,7 +218,16 @@ def metric_init(params):
 	}))
 
     descriptors.append(create_desc(Desc_Skel, {
-	"name"       : "tcp_" + "retrans_percentage",
+	"name"       : "tcp_attemptfails_percentage",
+	"call_back"  : get_tcpattemptfail_percentage,
+	"description": "TCP attemptfail percentage, tcpattemptfail / insegs + outsegs",
+	"units"      : "pct",
+        'groups'      : 'tcp'
+	}))
+
+
+    descriptors.append(create_desc(Desc_Skel, {
+	"name"       : "tcp_retrans_percentage",
 	"call_back"  : get_retrans_percentage,
 	"description": "TCP retrans percentage, retranssegs / insegs + outsegs",
 	"units"      : "pct",

--- a/gmond/python_modules/network/netstats.py
+++ b/gmond/python_modules/network/netstats.py
@@ -1,3 +1,7 @@
+# This module allows you to collect network stats. These values that are collected from
+#
+# /proc/net/netstat
+
 import sys
 import re
 import time

--- a/gmond/python_modules/nfs/nfsstats.py
+++ b/gmond/python_modules/nfs/nfsstats.py
@@ -1,5 +1,15 @@
 #!/usr/bin/python
 
+# This module reads NFS client and server statistics out of /proc and
+# creates a nfs_v3_* and nfsd_v3_* metric for each. 
+#
+# Originally based on Vladimir Vuksan's perl scripts, this version differs
+# in the following significant respects:
+#
+# 1) it is written as a python plugin
+# 2) the code is structured in a way intended to make it easy to repurpose
+#   the code for extracting other information out of /proc
+
 import os
 import stat
 import re

--- a/gmond/python_modules/nfs/nfsstats.py
+++ b/gmond/python_modules/nfs/nfsstats.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 # This module reads NFS client and server statistics out of /proc and
-# creates a nfs_v3_* and nfsd_v3_* metric for each. 
+# creates a nfs_v3_* and nfsd_v3_* metric for each.
 #
 # Originally based on Vladimir Vuksan's perl scripts, this version differs
 # in the following significant respects:
@@ -18,13 +18,14 @@ import syslog
 import sys
 import string
 
-def test_proc( p_file, p_string ):
+
+def test_proc(p_file, p_string):
     global p_match
     """
     Check if <p_file> contains keyword <p_string> e.g. proc3, proc4
     """
 
-    p_fd = open( p_file )
+    p_fd = open(p_file)
 
     p_contents = p_fd.read()
 
@@ -38,13 +39,13 @@ def test_proc( p_file, p_string ):
         return True
 
 verboselevel = 0
-descriptors = [ ]
-old_values = { }
+descriptors = []
+old_values = {}
 #  What we want ganglia to monitor, where to find it, how to extract it, ...
 configtable = [
     {
         'group': 'nfs_client',
-        'tests': [ 'stat.S_ISREG(os.stat("/proc/net/rpc/nfs").st_mode)', 'test_proc("/proc/net/rpc/nfs", "proc3")' ],
+        'tests': ['stat.S_ISREG(os.stat("/proc/net/rpc/nfs").st_mode)', 'test_proc("/proc/net/rpc/nfs", "proc3")'],
         'prefix': 'nfs_v3_',
         #  The next 4 lines can be at the 'group' level or the 'name' level
         'file': '/proc/net/rpc/nfs',
@@ -52,33 +53,33 @@ configtable = [
         'units': 'calls/sec',
         'format': '%f',
         'names': {
-            'total':       { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){2}(\d+.*\d)\n" },
-            'getattr':     { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){2}(\S*)" },
-            'setattr':     { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){3}(\S*)" },
-            'lookup':      { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){4}(\S*)" },
-            'access':      { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){5}(\S*)" },
-            'readlink':    { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){6}(\S*)" },
-            'read':        { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){7}(\S*)" },
-            'write':       { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){8}(\S*)" },
-            'create':      { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){9}(\S*)" },
-            'mkdir':       { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){10}(\S*)" },
-            'symlink':     { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){11}(\S*)" },
-            'mknod':       { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){12}(\S*)" },
-            'remove':      { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){13}(\S*)" },
-            'rmdir':       { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){14}(\S*)" },
-            'rename':      { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){15}(\S*)" },
-            'link':        { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){16}(\S*)" },
-            'readdir':     { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){17}(\S*)" },
-            'readdirplus': { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){18}(\S*)" },
-            'fsstat':      { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){19}(\S*)" },
-            'fsinfo':      { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){20}(\S*)" },
-            'pathconf':    { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){21}(\S*)" },
-            'commit':      { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){22}(\S*)" }
+            'total':       {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){2}(\d+.*\d)\n"},
+            'getattr':     {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){2}(\S*)"},
+            'setattr':     {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){3}(\S*)"},
+            'lookup':      {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){4}(\S*)"},
+            'access':      {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){5}(\S*)"},
+            'readlink':    {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){6}(\S*)"},
+            'read':        {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){7}(\S*)"},
+            'write':       {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){8}(\S*)"},
+            'create':      {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){9}(\S*)"},
+            'mkdir':       {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){10}(\S*)"},
+            'symlink':     {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){11}(\S*)"},
+            'mknod':       {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){12}(\S*)"},
+            'remove':      {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){13}(\S*)"},
+            'rmdir':       {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){14}(\S*)"},
+            'rename':      {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){15}(\S*)"},
+            'link':        {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){16}(\S*)"},
+            'readdir':     {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){17}(\S*)"},
+            'readdirplus': {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){18}(\S*)"},
+            'fsstat':      {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){19}(\S*)"},
+            'fsinfo':      {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){20}(\S*)"},
+            'pathconf':    {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){21}(\S*)"},
+            'commit':      {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){22}(\S*)"}
         }
     },
     {
         'group': 'nfs_client_v4',
-        'tests': [ 'stat.S_ISREG(os.stat("/proc/net/rpc/nfs").st_mode)', 'test_proc("/proc/net/rpc/nfs", "proc4")' ],
+        'tests': ['stat.S_ISREG(os.stat("/proc/net/rpc/nfs").st_mode)', 'test_proc("/proc/net/rpc/nfs", "proc4")'],
         'prefix': 'nfs_v4_',
         #  The next 4 lines can be at the 'group' level or the 'name' level
         'file': '/proc/net/rpc/nfs',
@@ -86,58 +87,58 @@ configtable = [
         'units': 'calls/sec',
         'format': '%f',
         'names': {
-            'total':        { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){2}(\d+.*\d)\n" },
-            'read':         { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){2}(\S*)" },
-            'write':        { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){3}(\S*)" },
-            'commit':       { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){4}(\S*)" },
-            'open':         { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){5}(\S*)" },
-            'open_conf':    { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){6}(\S*)" },
-            'open_noat':    { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){7}(\S*)" },
-            'open_dgrd':    { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){8}(\S*)" },
-            'close':        { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){9}(\S*)" },
-            'setattr':      { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){10}(\S*)" },
-            'renew':        { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){11}(\S*)" },
-            'setclntid':    { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){12}(\S*)" },
-            'confirm':      { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){13}(\S*)" },
-            'lock':         { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){14}(\S*)" },
-            'lockt':        { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){15}(\S*)" },
-            'locku':        { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){16}(\S*)" },
-            'access':       { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){17}(\S*)" },
-            'getattr':      { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){18}(\S*)" },
-            'lookup':       { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){19}(\S*)" },
-            'lookup_root':  { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){20}(\S*)" },
-            'remove':       { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){21}(\S*)" },
-            'rename':       { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){22}(\S*)" },
-            'link':         { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){23}(\S*)" },
-            'symlink':      { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){24}(\S*)" },
-            'create':       { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){25}(\S*)" },
-            'pathconf':     { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){26}(\S*)" },
-            'statfs':       { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){27}(\S*)" },
-            'readlink':     { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){28}(\S*)" },
-            'readdir':      { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){29}(\S*)" },
-            'server_caps':  { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){30}(\S*)" },
-            'delegreturn':  { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){31}(\S*)" },
-            'getacl':       { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){32}(\S*)" },
-            'setacl':       { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){33}(\S*)" },
-            'fs_locations': { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){34}(\S*)" },
-            'rel_lkowner':  { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){35}(\S*)" },
-            'secinfo':      { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){36}(\S*)" },
-            'exchange_id':  { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){37}(\S*)" },
-            'create_ses':   { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){38}(\S*)" },
-            'destroy_ses':  { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){39}(\S*)" },
-            'sequence':     { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){40}(\S*)" },
-            'get_lease_t':  { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){41}(\S*)" },
-            'reclaim_comp': { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){42}(\S*)" },
-            'layoutget':    { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){43}(\S*)" },
-            'getdevinfo':   { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){44}(\S*)" },
-            'layoutcommit': { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){45}(\S*)" },
-            'layoutreturn': { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){46}(\S*)" },
-            'getdevlist':   { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){47}(\S*)" }
+            'total':        {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){2}(\d+.*\d)\n"},
+            'read':         {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){2}(\S*)"},
+            'write':        {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){3}(\S*)"},
+            'commit':       {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){4}(\S*)"},
+            'open':         {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){5}(\S*)"},
+            'open_conf':    {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){6}(\S*)"},
+            'open_noat':    {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){7}(\S*)"},
+            'open_dgrd':    {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){8}(\S*)"},
+            'close':        {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){9}(\S*)"},
+            'setattr':      {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){10}(\S*)"},
+            'renew':        {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){11}(\S*)"},
+            'setclntid':    {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){12}(\S*)"},
+            'confirm':      {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){13}(\S*)"},
+            'lock':         {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){14}(\S*)"},
+            'lockt':        {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){15}(\S*)"},
+            'locku':        {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){16}(\S*)"},
+            'access':       {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){17}(\S*)"},
+            'getattr':      {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){18}(\S*)"},
+            'lookup':       {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){19}(\S*)"},
+            'lookup_root':  {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){20}(\S*)"},
+            'remove':       {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){21}(\S*)"},
+            'rename':       {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){22}(\S*)"},
+            'link':         {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){23}(\S*)"},
+            'symlink':      {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){24}(\S*)"},
+            'create':       {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){25}(\S*)"},
+            'pathconf':     {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){26}(\S*)"},
+            'statfs':       {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){27}(\S*)"},
+            'readlink':     {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){28}(\S*)"},
+            'readdir':      {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){29}(\S*)"},
+            'server_caps':  {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){30}(\S*)"},
+            'delegreturn':  {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){31}(\S*)"},
+            'getacl':       {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){32}(\S*)"},
+            'setacl':       {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){33}(\S*)"},
+            'fs_locations': {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){34}(\S*)"},
+            'rel_lkowner':  {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){35}(\S*)"},
+            'secinfo':      {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){36}(\S*)"},
+            'exchange_id':  {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){37}(\S*)"},
+            'create_ses':   {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){38}(\S*)"},
+            'destroy_ses':  {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){39}(\S*)"},
+            'sequence':     {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){40}(\S*)"},
+            'get_lease_t':  {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){41}(\S*)"},
+            'reclaim_comp': {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){42}(\S*)"},
+            'layoutget':    {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){43}(\S*)"},
+            'getdevinfo':   {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){44}(\S*)"},
+            'layoutcommit': {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){45}(\S*)"},
+            'layoutreturn': {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){46}(\S*)"},
+            'getdevlist':   {'description': 'dummy description', 're': ".*proc4 (?:\S*\s){47}(\S*)"}
         }
     },
     {
         'group': 'nfs_server',
-        'tests': [ 'stat.S_ISREG(os.stat("/proc/net/rpc/nfsd").st_mode)', 'test_proc("/proc/net/rpc/nfsd", "proc3")' ],
+        'tests': ['stat.S_ISREG(os.stat("/proc/net/rpc/nfsd").st_mode)', 'test_proc("/proc/net/rpc/nfsd", "proc3")'],
         'prefix': 'nfsd_v3_',
         #  The next 4 lines can be at the 'group' level or the 'name' level
         'file': '/proc/net/rpc/nfsd',
@@ -145,33 +146,33 @@ configtable = [
         'units': 'calls/sec',
         'format': '%f',
         'names': {
-            'total':       { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){2}(\d+.*\d)\n" },
-            'getattr':     { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){2}(\S*)" },
-            'setattr':     { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){3}(\S*)" },
-            'lookup':      { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){4}(\S*)" },
-            'access':      { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){5}(\S*)" },
-            'readlink':    { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){6}(\S*)" },
-            'read':        { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){7}(\S*)" },
-            'write':       { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){8}(\S*)" },
-            'create':      { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){9}(\S*)" },
-            'mkdir':       { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){10}(\S*)" },
-            'symlink':     { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){11}(\S*)" },
-            'mknod':       { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){12}(\S*)" },
-            'remove':      { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){13}(\S*)" },
-            'rmdir':       { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){14}(\S*)" },
-            'rename':      { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){15}(\S*)" },
-            'link':        { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){16}(\S*)" },
-            'readdir':     { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){17}(\S*)" },
-            'readdirplus': { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){18}(\S*)" },
-            'fsstat':      { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){19}(\S*)" },
-            'fsinfo':      { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){20}(\S*)" },
-            'pathconf':    { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){21}(\S*)" },
-            'commit':      { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){22}(\S*)" }
+            'total':       {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){2}(\d+.*\d)\n"},
+            'getattr':     {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){2}(\S*)"},
+            'setattr':     {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){3}(\S*)"},
+            'lookup':      {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){4}(\S*)"},
+            'access':      {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){5}(\S*)"},
+            'readlink':    {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){6}(\S*)"},
+            'read':        {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){7}(\S*)"},
+            'write':       {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){8}(\S*)"},
+            'create':      {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){9}(\S*)"},
+            'mkdir':       {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){10}(\S*)"},
+            'symlink':     {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){11}(\S*)"},
+            'mknod':       {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){12}(\S*)"},
+            'remove':      {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){13}(\S*)"},
+            'rmdir':       {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){14}(\S*)"},
+            'rename':      {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){15}(\S*)"},
+            'link':        {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){16}(\S*)"},
+            'readdir':     {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){17}(\S*)"},
+            'readdirplus': {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){18}(\S*)"},
+            'fsstat':      {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){19}(\S*)"},
+            'fsinfo':      {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){20}(\S*)"},
+            'pathconf':    {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){21}(\S*)"},
+            'commit':      {'description': 'dummy description', 're': ".*proc3 (?:\S*\s){22}(\S*)"}
         },
     },
     {
         'group': 'nfs_server_v4',
-        'tests': [ 'stat.S_ISREG(os.stat("/proc/net/rpc/nfsd").st_mode)', 'test_proc("/proc/net/rpc/nfsd", "proc4ops")' ],
+        'tests': ['stat.S_ISREG(os.stat("/proc/net/rpc/nfsd").st_mode)', 'test_proc("/proc/net/rpc/nfsd", "proc4ops")'],
         'prefix': 'nfsd_v4_',
         #  The next 4 lines can be at the 'group' level or the 'name' level
         'file': '/proc/net/rpc/nfsd',
@@ -179,69 +180,70 @@ configtable = [
         'units': 'calls/sec',
         'format': '%f',
         'names': {
-            'total':         { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){2}(\d+.*\d)\n" },
-            'op0-unused':    { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){1}(\S*)" },
-            'op1-unused':    { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){2}(\S*)" },
-            'op2-future':    { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){3}(\S*)" },
-            'access':        { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){4}(\S*)" },
-            'close':         { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){5}(\S*)" },
-            'commit':        { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){6}(\S*)" },
-            'create':        { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){7}(\S*)" },
-            'delegpurge':    { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){8}(\S*)" },
-            'delegreturn':   { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){9}(\S*)" },
-            'getattr':       { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){10}(\S*)" },
-            'getfh':         { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){11}(\S*)" },
-            'link':          { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){12}(\S*)" },
-            'lock':          { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){13}(\S*)" },
-            'lockt':         { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){14}(\S*)" },
-            'locku':         { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){15}(\S*)" },
-            'lookup':        { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){16}(\S*)" },
-            'lookup_root':   { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){17}(\S*)" },
-            'nverify':       { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){18}(\S*)" },
-            'open':          { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){19}(\S*)" },
-            'openattr':      { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){20}(\S*)" },
-            'open_conf':     { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){21}(\S*)" },
-            'open_dgrd':     { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){22}(\S*)" },
-            'putfh':         { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){23}(\S*)" },
-            'putpubfh':      { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){24}(\S*)" },
-            'putrootfh':     { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){25}(\S*)" },
-            'read':          { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){26}(\S*)" },
-            'readdir':       { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){27}(\S*)" },
-            'readlink':      { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){28}(\S*)" },
-            'remove':        { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){29}(\S*)" },
-            'rename':        { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){30}(\S*)" },
-            'renew':         { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){31}(\S*)" },
-            'restorefh':     { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){32}(\S*)" },
-            'savefh':        { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){33}(\S*)" },
-            'secinfo':       { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){34}(\S*)" },
-            'setattr':       { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){35}(\S*)" },
-            'setcltid':      { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){36}(\S*)" },
-            'setcltidconf':  { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){37}(\S*)" },
-            'verify':        { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){38}(\S*)" },
-            'write':         { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){39}(\S*)" },
-            'rellockowner':  { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){40}(\S*)" },
-            'bc_ctl':        { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){41}(\S*)" },
-            'bind_conn':     { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){42}(\S*)" },
-            'exchange_id':   { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){43}(\S*)" },
-            'create_ses':    { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){44}(\S*)" },
-            'destroy_ses':   { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){45}(\S*)" },
-            'free_stateid':  { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){46}(\S*)" },
-            'getdirdeleg':   { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){47}(\S*)" },
-            'getdevinfo':    { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){48}(\S*)" },
-            'getdevlist':    { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){49}(\S*)" },
-            'layoutcommit':  { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){50}(\S*)" },
-            'layoutget':     { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){51}(\S*)" },
-            'layoutreturn':  { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){52}(\S*)" },
-            'secinfononam':  { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){53}(\S*)" },
-            'sequence':      { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){54}(\S*)" },
-            'set_ssv':       { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){55}(\S*)" },
-            'test_stateid':  { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){56}(\S*)" },
-            'want_deleg':    { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){57}(\S*)" },
-            'destroy_clid':  { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){58}(\S*)" },
-            'reclaim_comp':  { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){59}(\S*)" }
+            'total':         {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){2}(\d+.*\d)\n"},
+            'op0-unused':    {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){1}(\S*)"},
+            'op1-unused':    {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){2}(\S*)"},
+            'op2-future':    {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){3}(\S*)"},
+            'access':        {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){4}(\S*)"},
+            'close':         {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){5}(\S*)"},
+            'commit':        {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){6}(\S*)"},
+            'create':        {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){7}(\S*)"},
+            'delegpurge':    {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){8}(\S*)"},
+            'delegreturn':   {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){9}(\S*)"},
+            'getattr':       {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){10}(\S*)"},
+            'getfh':         {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){11}(\S*)"},
+            'link':          {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){12}(\S*)"},
+            'lock':          {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){13}(\S*)"},
+            'lockt':         {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){14}(\S*)"},
+            'locku':         {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){15}(\S*)"},
+            'lookup':        {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){16}(\S*)"},
+            'lookup_root':   {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){17}(\S*)"},
+            'nverify':       {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){18}(\S*)"},
+            'open':          {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){19}(\S*)"},
+            'openattr':      {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){20}(\S*)"},
+            'open_conf':     {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){21}(\S*)"},
+            'open_dgrd':     {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){22}(\S*)"},
+            'putfh':         {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){23}(\S*)"},
+            'putpubfh':      {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){24}(\S*)"},
+            'putrootfh':     {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){25}(\S*)"},
+            'read':          {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){26}(\S*)"},
+            'readdir':       {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){27}(\S*)"},
+            'readlink':      {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){28}(\S*)"},
+            'remove':        {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){29}(\S*)"},
+            'rename':        {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){30}(\S*)"},
+            'renew':         {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){31}(\S*)"},
+            'restorefh':     {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){32}(\S*)"},
+            'savefh':        {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){33}(\S*)"},
+            'secinfo':       {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){34}(\S*)"},
+            'setattr':       {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){35}(\S*)"},
+            'setcltid':      {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){36}(\S*)"},
+            'setcltidconf':  {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){37}(\S*)"},
+            'verify':        {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){38}(\S*)"},
+            'write':         {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){39}(\S*)"},
+            'rellockowner':  {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){40}(\S*)"},
+            'bc_ctl':        {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){41}(\S*)"},
+            'bind_conn':     {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){42}(\S*)"},
+            'exchange_id':   {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){43}(\S*)"},
+            'create_ses':    {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){44}(\S*)"},
+            'destroy_ses':   {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){45}(\S*)"},
+            'free_stateid':  {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){46}(\S*)"},
+            'getdirdeleg':   {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){47}(\S*)"},
+            'getdevinfo':    {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){48}(\S*)"},
+            'getdevlist':    {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){49}(\S*)"},
+            'layoutcommit':  {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){50}(\S*)"},
+            'layoutget':     {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){51}(\S*)"},
+            'layoutreturn':  {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){52}(\S*)"},
+            'secinfononam':  {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){53}(\S*)"},
+            'sequence':      {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){54}(\S*)"},
+            'set_ssv':       {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){55}(\S*)"},
+            'test_stateid':  {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){56}(\S*)"},
+            'want_deleg':    {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){57}(\S*)"},
+            'destroy_clid':  {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){58}(\S*)"},
+            'reclaim_comp':  {'description': 'dummy description', 're': ".*proc4ops (?:\S*\s){59}(\S*)"}
         },
     }
 ]
+
 
 #  Ganglia will call metric_init(), which should return a dictionary for each thing that it
 #  should monitor, including the name of the callback function to get the current value.
@@ -256,13 +258,13 @@ def metric_init(params):
         for j in range(0, len(configtable[i]['tests'])):
             try:
                 if eval(configtable[i]['tests'][j]):
-		    pass
+                    pass
                 else:
                     tests_passed = False
                     break
             except:
-               tests_passed = False
-               break
+                tests_passed = False
+                break
         if not tests_passed:
             continue
 
@@ -276,7 +278,7 @@ def metric_init(params):
         for _tmpkey in names_keys:
             _tmplist = names_keys
             param_pos = re.split("{(\d+)\}", configtable[i]['names'][_tmpkey].values()[0])[1]
-	    if int(param_pos) > int(max_plimit):
+            if int(param_pos) > int(max_plimit):
                 keys_to_remove.append(_tmpkey)
             n += 1
 
@@ -288,22 +290,21 @@ def metric_init(params):
         for name in names_keys:
             #  ... set up dictionary ...
             if 'format' in configtable[i]['names'][name]:
-		format_str = configtable[i]['names'][name]['format']
+                format_str = configtable[i]['names'][name]['format']
             else:
-		format_str = configtable[i]['format']
+                format_str = configtable[i]['format']
             if 'units' in configtable[i]['names'][name]:
-		unit_str = configtable[i]['names'][name]['units']
+                unit_str = configtable[i]['names'][name]['units']
             else:
-		unit_str = configtable[i]['units']
+                unit_str = configtable[i]['units']
             if 'value_type' in configtable[i]['names'][name]:
-		value_type_str = configtable[i]['names'][name]['value_type']
+                value_type_str = configtable[i]['names'][name]['value_type']
             else:
-		value_type_str = configtable[i]['value_type']
+                value_type_str = configtable[i]['value_type']
             if 'file' in configtable[i]['names'][name]:
-		file_str = configtable[i]['names'][name]['file']
+                file_str = configtable[i]['names'][name]['file']
             else:
-		file_str = configtable[i]['file']
-		
+                file_str = configtable[i]['file']
 
             descriptors.append({
                 'name': configtable[i]['prefix'] + name,
@@ -320,18 +321,20 @@ def metric_init(params):
                 're': configtable[i]['names'][name]['re']
             })
             #  And get current value cached as previous value, for future comparisons.
-            (ts, value) =  get_value(configtable[i]['prefix'] + name)
-            old_values[configtable[i]['prefix'] + name] = { 
-                'time':ts,
-                'value':value
+            (ts, value) = get_value(configtable[i]['prefix'] + name)
+            old_values[configtable[i]['prefix'] + name] = {
+                'time': ts,
+                'value': value
             }
 
     #  Pass ganglia the complete list of dictionaries.
     return descriptors
 
+
 #  Ganglia will call metric_cleanup() when it exits.
 def metric_cleanup():
     pass
+
 
 #  metric_init() registered this as the callback function.
 def call_back(name):
@@ -339,10 +342,10 @@ def call_back(name):
 
     #  Get new value
     (new_time, new_value) = get_value(name)
- 
-    #  Calculate rate of change 
+
+    #  Calculate rate of change
     try:
-        rate = (new_value - old_values[name]['value'])/(new_time - old_values[name]['time'])
+        rate = (new_value - old_values[name]['value']) / (new_time - old_values[name]['time'])
     except ZeroDivisionError:
         rate = 0.0
 
@@ -350,6 +353,7 @@ def call_back(name):
     old_values[name]['value'] = new_value
     old_values[name]['time'] = new_time
     return rate
+
 
 def get_value(name):
     global descriptors
@@ -364,8 +368,8 @@ def get_value(name):
     m_value = m.group(1)
 
     #RB: multiple (space seperated) values: calculate sum
-    if string.count( m_value, ' ' ) > 0:
-        m_fields = string.split( m_value, ' ' )
+    if string.count(m_value, ' ') > 0:
+        m_fields = string.split(m_value, ' ')
 
         sum_value = 0
 
@@ -373,10 +377,11 @@ def get_value(name):
             sum_value = sum_value + int(f)
 
         m_value = sum_value
-    
+
     #  Return time and value.
     ts = time.time()
     return (ts, int(m_value))
+
 
 def debug(level, text):
     global verboselevel

--- a/gmond/python_modules/process/procstat.py
+++ b/gmond/python_modules/process/procstat.py
@@ -98,12 +98,13 @@
 ###  License to use, modify, and distribute under the GPL
 ###  http://www.gnu.org/licenses/gpl.txt
 
-import time
-import subprocess
-import traceback, sys
-import os.path
 import glob
 import logging
+import os.path
+import subprocess
+import sys
+import time
+import traceback
 
 descriptors = []
 
@@ -120,390 +121,399 @@ MAX_UPDATE_TIME = 15
 # clock ticks per second... jiffies (HZ)
 JIFFIES_PER_SEC = os.sysconf('SC_CLK_TCK')
 
-PAGE_SIZE=os.sysconf('SC_PAGE_SIZE')
+PAGE_SIZE = os.sysconf('SC_PAGE_SIZE')
 
 PROCESSES = {}
 
+
 def readCpu(pid):
-	try:
-		stat = file('/proc/' + pid + '/stat', 'rt').readline().split()
-		#logging.debug(' stat (' + pid + '): ' + str(stat))
-		utime = int(stat[13])
-		stime = int(stat[14])
-		cutime = int(stat[15])
-		cstime = int(stat[16])
-		return (utime + stime + cutime + cstime)
-	except:
-		logging.warning('failed to get (' + str(pid) + ') stats')
-		return 0
+    try:
+        stat = file('/proc/' + pid + '/stat', 'rt').readline().split()
+        #logging.debug(' stat (' + pid + '): ' + str(stat))
+        utime = int(stat[13])
+        stime = int(stat[14])
+        cutime = int(stat[15])
+        cstime = int(stat[16])
+        return (utime + stime + cutime + cstime)
+    except:
+        logging.warning('failed to get (' + str(pid) + ') stats')
+        return 0
+
 
 def get_pgid(proc):
-	logging.debug('getting pgid for process: ' + proc)
-	ERROR = 0
+    logging.debug('getting pgid for process: ' + proc)
+    ERROR = 0
 
-	if pgid_list.has_key(proc) and os.path.exists('/proc/' + pgid_list[proc][0]):
-		return pgid_list[proc]
+    if pgid_list.has_key(proc) and os.path.exists('/proc/' + pgid_list[proc][0]):
+        return pgid_list[proc]
 
-	val = PROCESSES[proc]
-	# Is this a pidfile? Last 4 chars are .pid
-	if '.pid' in val[-4:]:
-		if os.path.exists(val):
-			logging.debug(' pidfile found')
-			ppid = file(val, 'rt').readline().strip()
-			pgid = file('/proc/' + ppid + '/stat', 'rt').readline().split()[4]
-		else:
-			raise Exception('pidfile (' + val + ') does not exist')
+    val = PROCESSES[proc]
+    # Is this a pidfile? Last 4 chars are .pid
+    if '.pid' in val[-4:]:
+        if os.path.exists(val):
+            logging.debug(' pidfile found')
+            ppid = file(val, 'rt').readline().strip()
+            pgid = file('/proc/' + ppid + '/stat', 'rt').readline().split()[4]
+        else:
+            raise Exception('pidfile (' + val + ') does not exist')
 
-	else:
-		# This is a regex, lets search for it
-		regex = PROCESSES[proc]
-		cmd = "ps -Ao pid,ppid,pgid,args | awk '" + regex + " && $2 == 1 && !/awk/ && !/procstat\.py/ {print $0}'"
-		p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-		out, err = p.communicate()
+    else:
+        # This is a regex, lets search for it
+        regex = PROCESSES[proc]
+        cmd = "ps -Ao pid,ppid,pgid,args | awk '" + regex + " && $2 == 1 && !/awk/ && !/procstat\.py/ {print $0}'"
+        p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out, err = p.communicate()
 
-		if p.returncode:
-			raise Exception('failed executing ps\n' + cmd + '\n' + err)
+        if p.returncode:
+            raise Exception('failed executing ps\n' + cmd + '\n' + err)
 
-		result = out.strip().split('\n')
-		logging.debug(' result: ' + str(result))
+        result = out.strip().split('\n')
+        logging.debug(' result: ' + str(result))
 
-		if len(result) > 1:
-			raise Exception('more than 1 result returned\n' + cmd + '\n' + out.strip())
+        if len(result) > 1:
+            raise Exception('more than 1 result returned\n' + cmd + '\n' + out.strip())
 
-		if result[0] in '':
-			raise Exception('no process returned\n' + cmd)
+        if result[0] in '':
+            raise Exception('no process returned\n' + cmd)
 
-		res = result[0].split()
-		ppid = res[0]
-		pgid = res[2]
+        res = result[0].split()
+        ppid = res[0]
+        pgid = res[2]
 
-	if os.path.exists('/proc/' + ppid):
-		logging.debug(' ppid: ' + ppid + ' pgid: ' + pgid)
-		return (ppid, pgid)
-	else:
-		return ERROR
+    if os.path.exists('/proc/' + ppid):
+        logging.debug(' ppid: ' + ppid + ' pgid: ' + pgid)
+        return (ppid, pgid)
+    else:
+        return ERROR
+
 
 def get_pgroup(ppid, pgid):
-	'''Return a list of pids having the same pgid, with the first in the list being the parent pid.'''
-	logging.debug('getting pids for ppid/pgid: ' + ppid + '/' + pgid)
+    '''Return a list of pids having the same pgid, with the first in the list being the parent pid.'''
+    logging.debug('getting pids for ppid/pgid: ' + ppid + '/' + pgid)
 
-	try:
-		# Get all processes in this group
-		p_list = []
-		for stat_file in glob.glob('/proc/[1-9]*/stat'):
-			stat = file(stat_file, 'rt').readline().split()
-			if stat[4] == pgid:
-				p_list.append(stat[0])
+    try:
+        # Get all processes in this group
+        p_list = []
+        for stat_file in glob.glob('/proc/[1-9]*/stat'):
+            stat = file(stat_file, 'rt').readline().split()
+            if stat[4] == pgid:
+                p_list.append(stat[0])
 
-		# place pid at the top of the list
-		p_list.remove(ppid)
-		p_list.insert(0, ppid)
+        # place pid at the top of the list
+        p_list.remove(ppid)
+        p_list.insert(0, ppid)
 
-		logging.debug('p_list: ' + str(p_list))
+        logging.debug('p_list: ' + str(p_list))
 
-		return p_list
+        return p_list
 
-	except:
-		logging.warning('failed getting pids')
+    except:
+        logging.warning('failed getting pids')
+
 
 def get_rss(pids):
-	logging.debug('getting rss for pids')
+    logging.debug('getting rss for pids')
 
-	rss = 0
-	for p in pids:
-		try:
-			statm = open('/proc/' + p + '/statm', 'rt').readline().split()
-			#logging.debug(' statm (' + p + '): ' + str(statm))
-		except:
-			# Process finished, ignore this mem usage
-			logging.warning(' failed getting statm for pid: ' + p)
-			continue
+    rss = 0
+    for p in pids:
+        try:
+            statm = open('/proc/' + p + '/statm', 'rt').readline().split()
+            #logging.debug(' statm (' + p + '): ' + str(statm))
+        except:
+            # Process finished, ignore this mem usage
+            logging.warning(' failed getting statm for pid: ' + p)
+            continue
 
-		rss += int(statm[1])
+        rss += int(statm[1])
 
-	rss *= PAGE_SIZE
-	return rss
+    rss *= PAGE_SIZE
+    return rss
+
 
 def test(params):
-	global PROCESSES, MAX_UPDATE_TIME
+    global PROCESSES, MAX_UPDATE_TIME
 
-	MAX_UPDATE_TIME = 2
+    MAX_UPDATE_TIME = 2
 
-	logging.debug('testing processes: ' + str(params))
+    logging.debug('testing processes: ' + str(params))
 
-	PROCESSES = params
+    PROCESSES = params
 
-	for proc,val in PROCESSES.items():
-		print('')
-		print(' Testing ' + proc + ': ' + val) 
+    for proc, val in PROCESSES.items():
+        print('')
+        print(' Testing ' + proc + ': ' + val)
 
-		try:
-			(ppid, pgid) = get_pgid(proc)
-		except Exception, e:
-			print(' failed getting pgid: ' + str(e))
-			continue
+        try:
+            (ppid, pgid) = get_pgid(proc)
+        except Exception, e:
+            print(' failed getting pgid: ' + str(e))
+            continue
 
-		pids = get_pgroup(ppid, pgid)
+        pids = get_pgroup(ppid, pgid)
 
-		print(' Processes in this group: ')
-		print(' PID, ARGS')
-		for pid in pids:
-			# Read from binary file containing command line arguments
-			args = file('/proc/' + pid + '/cmdline', 'rt').readline().replace('\0', ' ')
-			print(' ' + pid + ' ' + args)
+        print(' Processes in this group: ')
+        print(' PID, ARGS')
+        for pid in pids:
+            # Read from binary file containing command line arguments
+            args = file('/proc/' + pid + '/cmdline', 'rt').readline().replace('\0', ' ')
+            print(' ' + pid + ' ' + args)
 
-	logging.debug('success testing')
+    logging.debug('success testing')
+
 
 def update_stats():
-	logging.debug('updating stats')
-	global last_update, stats, last_val
-	
-	cur_time = time.time()
+    logging.debug('updating stats')
+    global last_update, stats, last_val
 
-	if cur_time - last_update < MAX_UPDATE_TIME:
-		logging.debug(' wait ' + str(int(MAX_UPDATE_TIME - (cur_time - last_update))) + ' seconds')
-		return True
-	else:
-		last_update = cur_time
+    cur_time = time.time()
 
-	for proc,val in PROCESSES.items():
-		logging.debug(' updating for ' + proc)
+    if cur_time - last_update < MAX_UPDATE_TIME:
+        logging.debug(' wait ' + str(int(MAX_UPDATE_TIME - (cur_time - last_update))) + ' seconds')
+        return True
+    else:
+        last_update = cur_time
 
-		# setup storage lists
-		if not proc in stats:
-			stats[proc] = {}
-		if not proc in last_val:
-			last_val[proc] = {}
+    for proc, val in PROCESSES.items():
+        logging.debug(' updating for ' + proc)
 
-		#####
-		# Update CPU utilization
-		try:
-			(ppid, pgid) = get_pgid(proc)
-		except Exception, e:
-			logging.warning(' failed getting pgid: ' + str(e))
-			stats[proc]['cpu'] = 0.0
-			stats[proc]['mem'] = 0
-			continue
+        # setup storage lists
+        if not proc in stats:
+            stats[proc] = {}
+        if not proc in last_val:
+            last_val[proc] = {}
 
-		# save for later
-		pgid_list[proc] = (ppid, pgid)
+        #####
+        # Update CPU utilization
+        try:
+            (ppid, pgid) = get_pgid(proc)
+        except Exception, e:
+            logging.warning(' failed getting pgid: ' + str(e))
+            stats[proc]['cpu'] = 0.0
+            stats[proc]['mem'] = 0
+            continue
 
-		pids = get_pgroup(ppid, pgid)
+        # save for later
+        pgid_list[proc] = (ppid, pgid)
 
-		cpu_time = time.time()
-		proc_time = 0
-		for p in pids:
-			proc_time += readCpu(p)
-		
-		logging.debug(' proc_time: ' + str(proc_time) + ' cpu_time: ' + str(cpu_time))
+        pids = get_pgroup(ppid, pgid)
 
-		# do we have an old value to calculate with?
-		if 'cpu_time' in last_val[proc]:
-			logging.debug(' last_val: ' + str(last_val[proc]))
-			logging.debug(' calc: 100 * ' + str(proc_time - last_val[proc]['proc_time']) + ' / ' + str(cpu_time - last_val[proc]['cpu_time']) + ' * ' + str(JIFFIES_PER_SEC))
-			stats[proc]['cpu'] = 100 * (proc_time - last_val[proc]['proc_time']) / float((cpu_time - last_val[proc]['cpu_time']) * JIFFIES_PER_SEC)
+        cpu_time = time.time()
+        proc_time = 0
+        for p in pids:
+            proc_time += readCpu(p)
 
-			logging.debug(' calc: ' + str(stats[proc]['cpu']))
-		else:
-			stats[proc]['cpu'] = 0.0
+        logging.debug(' proc_time: ' + str(proc_time) + ' cpu_time: ' + str(cpu_time))
 
-		last_val[proc]['cpu_time'] = cpu_time
-		last_val[proc]['proc_time'] = proc_time
+        # do we have an old value to calculate with?
+        if 'cpu_time' in last_val[proc]:
+            logging.debug(' last_val: ' + str(last_val[proc]))
+            logging.debug(' calc: 100 * ' + str(proc_time - last_val[proc]['proc_time']) + ' / ' + str(cpu_time - last_val[proc]['cpu_time']) + ' * ' + str(JIFFIES_PER_SEC))
+            stats[proc]['cpu'] = 100 * (proc_time - last_val[proc]['proc_time']) / float((cpu_time - last_val[proc]['cpu_time']) * JIFFIES_PER_SEC)
 
-		#####
-		# Update Mem utilization	
-		rss = get_rss(pids)
-		stats[proc]['mem'] = rss
-	
-	logging.debug('success refreshing stats')
-	logging.debug('stats: ' + str(stats))
+            logging.debug(' calc: ' + str(stats[proc]['cpu']))
+        else:
+            stats[proc]['cpu'] = 0.0
 
-	return True
+        last_val[proc]['cpu_time'] = cpu_time
+        last_val[proc]['proc_time'] = proc_time
+
+        #####
+        # Update Mem utilization
+        rss = get_rss(pids)
+        stats[proc]['mem'] = rss
+
+    logging.debug('success refreshing stats')
+    logging.debug('stats: ' + str(stats))
+
+    return True
+
 
 def get_stat(name):
-	logging.debug('getting stat: ' + name)
+    logging.debug('getting stat: ' + name)
 
-	ret = update_stats()
+    ret = update_stats()
 
-	if ret:
-		if name.startswith('procstat_'):
-			fir = name.find('_')
-			sec = name.find('_', fir + 1)
+    if ret:
+        if name.startswith('procstat_'):
+            fir = name.find('_')
+            sec = name.find('_', fir + 1)
 
-			proc = name[fir+1:sec]
-			label = name[sec+1:]
+            proc = name[fir + 1:sec]
+            label = name[sec + 1:]
 
-			try:
-				return stats[proc][label]
-			except:
-				logging.warning('failed to fetch [' + proc + '] ' + name)
-				return 0
-		else:
-			label = name
+            try:
+                return stats[proc][label]
+            except:
+                logging.warning('failed to fetch [' + proc + '] ' + name)
+                return 0
+        else:
+            label = name
 
-		try:
-			return stats[label]
-		except:
-			logging.warning('failed to fetch ' + name)
-			return 0
-	else:
-		return 0
+        try:
+            return stats[label]
+        except:
+            logging.warning('failed to fetch ' + name)
+            return 0
+    else:
+        return 0
+
 
 def metric_init(params):
-	global descriptors
-	global PROCESSES
+    global descriptors
+    global PROCESSES
 
-	logging.debug('init: ' + str(params))
+    logging.debug('init: ' + str(params))
 
-	PROCESSES = params
+    PROCESSES = params
 
-	#for proc,regex in PROCESSES.items():
-		
-	update_stats()
+    #for proc,regex in PROCESSES.items():
 
-	descriptions = dict(
-		cpu = {
-			'units': 'percent',
-			'value_type': 'float',
-			'format': '%.1f',
-			'description': 'The total percent CPU utilization'},
+    update_stats()
 
-		mem = {
-			'units': 'B',
-			'description': 'The total memory utilization'}
-	)
+    descriptions = dict(
+        cpu = {
+            'units': 'percent',
+            'value_type': 'float',
+            'format': '%.1f',
+            'description': 'The total percent CPU utilization'},
 
-	time_max = 60
-	for label in descriptions:
-		for proc in PROCESSES:
-			if stats[proc].has_key(label):
+        mem = {
+            'units': 'B',
+            'description': 'The total memory utilization'}
+    )
 
-				d = {
-					'name': 'procstat_' + proc + '_' + label,
-					'call_back': get_stat,
-					'time_max': time_max,
-					'value_type': 'uint',
-					'units': '',
-					'slope': 'both',
-					'format': '%u',
-					'description': label,
-					'groups': 'procstat'
-				}
+    time_max = 60
+    for label in descriptions:
+        for proc in PROCESSES:
+            if stats[proc].has_key(label):
 
-				# Apply metric customizations from descriptions
-				d.update(descriptions[label])
+                d = {
+                    'name': 'procstat_' + proc + '_' + label,
+                    'call_back': get_stat,
+                    'time_max': time_max,
+                    'value_type': 'uint',
+                    'units': '',
+                    'slope': 'both',
+                    'format': '%u',
+                    'description': label,
+                    'groups': 'procstat'
+                }
 
-				descriptors.append(d)
+                # Apply metric customizations from descriptions
+                d.update(descriptions[label])
 
-			else:
-				logging.error("skipped " + proc + '_' + label)
+                descriptors.append(d)
 
-	#logging.debug('descriptors: ' + str(descriptors))
+            else:
+                logging.error("skipped " + proc + '_' + label)
 
-	return descriptors
+    #logging.debug('descriptors: ' + str(descriptors))
+
+    return descriptors
+
 
 def display_proc_stat(pid):
-	try:
-		stat = file('/proc/' + pid + '/stat', 'rt').readline().split()
+    try:
+        stat = file('/proc/' + pid + '/stat', 'rt').readline().split()
 
-		fields = [
-			'pid', 'comm', 'state', 'ppid', 'pgrp', 'session',
-			'tty_nr', 'tty_pgrp', 'flags', 'min_flt', 'cmin_flt', 'maj_flt',
-			'cmaj_flt', 'utime', 'stime', 'cutime', 'cstime', 'priority',
-			'nice', 'num_threads', 'it_real_value', 'start_time', 'vsize', 'rss',
-			'rlim', 'start_code', 'end_code', 'start_stack', 'esp', 'eip',
-			'pending', 'blocked', 'sigign', 'sigcatch', 'wchan', 'nswap',
-			'cnswap', 'exit_signal', 'processor', 'rt_priority', 'policy'
-		]
+        fields = [
+            'pid', 'comm', 'state', 'ppid', 'pgrp', 'session',
+            'tty_nr', 'tty_pgrp', 'flags', 'min_flt', 'cmin_flt', 'maj_flt',
+            'cmaj_flt', 'utime', 'stime', 'cutime', 'cstime', 'priority',
+            'nice', 'num_threads', 'it_real_value', 'start_time', 'vsize', 'rss',
+            'rlim', 'start_code', 'end_code', 'start_stack', 'esp', 'eip',
+            'pending', 'blocked', 'sigign', 'sigcatch', 'wchan', 'nswap',
+            'cnswap', 'exit_signal', 'processor', 'rt_priority', 'policy'
+        ]
 
-		# Display them
-		i = 0
-		for f in fields:
-			print '%15s: %s' % (f, stat[i])
-			i += 1
+        # Display them
+        i = 0
+        for f in fields:
+            print '%15s: %s' % (f, stat[i])
+            i += 1
 
-	except:
-		print('failed to get /proc/' + pid + '/stat')
-		print(traceback.print_exc(file=sys.stdout))
+    except:
+        print('failed to get /proc/' + pid + '/stat')
+        print(traceback.print_exc(file=sys.stdout))
+
 
 def display_proc_statm(pid):
-	try:
-		statm = file('/proc/' + pid + '/statm', 'rt').readline().split()
+    try:
+        statm = file('/proc/' + pid + '/statm', 'rt').readline().split()
 
-		fields = [
-			'size', 'rss', 'share', 'trs', 'drs', 'lrs' ,'dt' 
-		]
+        fields = [
+            'size', 'rss', 'share', 'trs', 'drs', 'lrs', 'dt'
+        ]
 
-		# Display them
-		i = 0
-		for f in fields:
-			print '%15s: %s' % (f, statm[i])
-			i += 1
+        # Display them
+        i = 0
+        for f in fields:
+            print '%15s: %s' % (f, statm[i])
+            i += 1
 
-	except:
-		print('failed to get /proc/' + pid + '/statm')
-		print(traceback.print_exc(file=sys.stdout))
+    except:
+        print('failed to get /proc/' + pid + '/statm')
+        print(traceback.print_exc(file=sys.stdout))
+
 
 def metric_cleanup():
-	logging.shutdown()
-	# pass
+    logging.shutdown()
+    # pass
 
 if __name__ == '__main__':
-	from optparse import OptionParser
-	import os
+    from optparse import OptionParser
+    import os
 
-	logging.debug('running from cmd line')
-	parser = OptionParser()
-	parser.add_option('-p', '--processes', dest='processes', default='', help='processes to explicitly check')
-	parser.add_option('-v', '--value', dest='value', default='', help='regex or pidfile for each processes')
-	parser.add_option('-s', '--stat', dest='stat', default='', help='display the /proc/[pid]/stat file for this pid')
-	parser.add_option('-m', '--statm', dest='statm', default='', help='display the /proc/[pid]/statm file for this pid')
-	parser.add_option('-b', '--gmetric-bin', dest='gmetric_bin', default='/usr/bin/gmetric', help='path to gmetric binary')
-	parser.add_option('-c', '--gmond-conf', dest='gmond_conf', default='/etc/ganglia/gmond.conf', help='path to gmond.conf')
-	parser.add_option('-g', '--gmetric', dest='gmetric', action='store_true', default=False, help='submit via gmetric')
-	parser.add_option('-q', '--quiet', dest='quiet', action='store_true', default=False)
-	parser.add_option('-t', '--test', dest='test', action='store_true', default=False, help='test the regex list')
+    logging.debug('running from cmd line')
+    parser = OptionParser()
+    parser.add_option('-p', '--processes', dest='processes', default='', help='processes to explicitly check')
+    parser.add_option('-v', '--value', dest='value', default='', help='regex or pidfile for each processes')
+    parser.add_option('-s', '--stat', dest='stat', default='', help='display the /proc/[pid]/stat file for this pid')
+    parser.add_option('-m', '--statm', dest='statm', default='', help='display the /proc/[pid]/statm file for this pid')
+    parser.add_option('-b', '--gmetric-bin', dest='gmetric_bin', default='/usr/bin/gmetric', help='path to gmetric binary')
+    parser.add_option('-c', '--gmond-conf', dest='gmond_conf', default='/etc/ganglia/gmond.conf', help='path to gmond.conf')
+    parser.add_option('-g', '--gmetric', dest='gmetric', action='store_true', default=False, help='submit via gmetric')
+    parser.add_option('-q', '--quiet', dest='quiet', action='store_true', default=False)
+    parser.add_option('-t', '--test', dest='test', action='store_true', default=False, help='test the regex list')
 
-	(options, args) = parser.parse_args()
+    (options, args) = parser.parse_args()
 
-	if options.stat != '':
-		display_proc_stat(options.stat)
-		sys.exit(0)
-	elif options.statm != '':
-		display_proc_statm(options.statm)
-		sys.exit(0)
+    if options.stat != '':
+        display_proc_stat(options.stat)
+        sys.exit(0)
+    elif options.statm != '':
+        display_proc_statm(options.statm)
+        sys.exit(0)
 
-	_procs = options.processes.split(',')
-	_val = options.value.split(',')
-	params = {}
-	i = 0
-	for proc in _procs:
-		params[proc] = _val[i]
-		i += 1
-	
-	if options.test:
-		test(params)
-		update_stats()
+    _procs = options.processes.split(',')
+    _val = options.value.split(',')
+    params = {}
+    i = 0
+    for proc in _procs:
+        params[proc] = _val[i]
+        i += 1
 
-		print('')
-		print(' waiting ' + str(MAX_UPDATE_TIME) + ' seconds')
-		time.sleep(MAX_UPDATE_TIME)
+    if options.test:
+        test(params)
+        update_stats()
 
-	metric_init(params)
+        print('')
+        print(' waiting ' + str(MAX_UPDATE_TIME) + ' seconds')
+        time.sleep(MAX_UPDATE_TIME)
 
-	for d in descriptors:
-		v = d['call_back'](d['name'])
-		if not options.quiet:
-			print ' %s: %s %s [%s]' % (d['name'], d['format'] % v, d['units'], d['description'])
+    metric_init(params)
 
-		if options.gmetric:
-			if d['value_type'] == 'uint':
-				value_type = 'uint32'
-			else:
-				value_type = d['value_type']
+    for d in descriptors:
+        v = d['call_back'](d['name'])
+        if not options.quiet:
+            print ' %s: %s %s [%s]' % (d['name'], d['format'] % v, d['units'], d['description'])
 
-			cmd = "%s --conf=%s --value='%s' --units='%s' --type='%s' --name='%s' --slope='%s'" % \
-				(options.gmetric_bin, options.gmond_conf, v, d['units'], value_type, d['name'], d['slope'])
-			os.system(cmd)
+        if options.gmetric:
+            if d['value_type'] == 'uint':
+                value_type = 'uint32'
+            else:
+                value_type = d['value_type']
 
-
+            cmd = "%s --conf=%s --value='%s' --units='%s' --type='%s' --name='%s' --slope='%s'" % \
+                (options.gmetric_bin, options.gmond_conf, v, d['units'], value_type, d['name'], d['slope'])
+            os.system(cmd)

--- a/gmond/python_modules/process/procstat.py
+++ b/gmond/python_modules/process/procstat.py
@@ -120,8 +120,7 @@ MAX_UPDATE_TIME = 15
 # clock ticks per second... jiffies (HZ)
 JIFFIES_PER_SEC = os.sysconf('SC_CLK_TCK')
 
-# KiB
-PAGE_SIZE=os.sysconf('SC_PAGE_SIZE') / 1024
+PAGE_SIZE=os.sysconf('SC_PAGE_SIZE')
 
 PROCESSES = {}
 
@@ -222,7 +221,6 @@ def get_rss(pids):
 
 		rss += int(statm[1])
 
-	# Convert to KiB
 	rss *= PAGE_SIZE
 	return rss
 
@@ -371,7 +369,7 @@ def metric_init(params):
 			'description': 'The total percent CPU utilization'},
 
 		mem = {
-			'units': 'KB',
+			'units': 'B',
 			'description': 'The total memory utilization'}
 	)
 

--- a/gmond/python_modules/ssl/entropy.py
+++ b/gmond/python_modules/ssl/entropy.py
@@ -1,3 +1,12 @@
+# This module allows you to collect available entropy on your system. Why is
+# entropy important.
+# [http://www.chrissearle.org/node/326]
+#   There are two random number sources on linux - /dev/random and /dev/urandom.
+#   /dev/random will block if there is nothing left in the entropy bit bucket.
+#   /dev/urandom uses the same bucket - but will not block
+#   (it can reuse the pool of bits).
+# Therefore if you are running SSL on the box you want to know this.
+
 import sys
 
 

--- a/gmond/python_modules/ssl/entropy.py
+++ b/gmond/python_modules/ssl/entropy.py
@@ -12,7 +12,8 @@ import sys
 
 entropy_file = "/proc/sys/kernel/random/entropy_avail"
 
-def metrics_handler(name):  
+
+def metrics_handler(name):
     try:
         f = open(entropy_file, 'r')
 
@@ -23,6 +24,7 @@ def metrics_handler(name):
         line = l
 
     return int(line)
+
 
 def metric_init(params):
     global descriptors, node_id
@@ -40,6 +42,7 @@ def metric_init(params):
     descriptors = [dict]
 
     return descriptors
+
 
 def metric_cleanup():
     '''Clean up the metric module.'''

--- a/gmond/python_modules/varnish/varnish.py
+++ b/gmond/python_modules/varnish/varnish.py
@@ -824,6 +824,199 @@ def metric_init(lparams):
                 "description": "Client uptime",
                 }))
 
+    ##############################################################################
+    
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'backend_retry',
+                "call_back"  : get_delta,
+                "units"      : "retries/s",
+                "description": "Backend conn. retry",
+                }))
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'dir_dns_cache_full',
+                "call_back"  : get_delta,
+                "units"      : "/s",
+                "description": "DNS director full dnscache",
+                }))
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'dir_dns_failed',
+                "call_back"  : get_delta,
+                "units"      : "/s",
+                "description": "DNS director failed lookups",
+                }))
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'dir_dns_hit',
+                "call_back"  : get_delta,
+                "units"      : "/s",
+                "description": "DNS director cached lookups hit",
+                }))
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'dir_dns_lookups',
+                "call_back"  : get_delta,
+                "units"      : "/s",
+                "description": "DNS director lookups",
+                }))
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'esi_warnings',
+                "call_back"  : get_delta,
+                "units"      : "/s",
+                "description": "ESI parse warnings (unlock)",
+                }))
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'fetch_1xx',
+                "call_back"  : get_delta,
+                "units"      : "/s",
+                "description": "Fetch no body (1xx)",
+                }))
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'fetch_204',
+                "call_back"  : get_delta,
+                "units"      : "/s",
+                "description": "Fetch no body (204)",
+                }))
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'fetch_304',
+                "call_back"  : get_delta,
+                "units"      : "/s",
+                "description": "Fetch no body (304)",
+                }))
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'n_ban',
+                "call_back"  : get_delta,
+                "units"      : "/s",
+                "description": "N total active bans",
+                }))
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'n_ban_add',
+                "call_back"  : get_delta,
+                "units"      : "/s",
+                "description": "N new bans added",
+                }))
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'n_ban_retire',
+                "call_back"  : get_delta,
+                "units"      : "/s",
+                "description": "N old bans deleted",
+                }))
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'n_ban_obj_test',
+                "call_back"  : get_delta,
+                "units"      : "/s",
+                "description": "N objects tested",
+                }))
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'n_ban_re_test',
+                "call_back"  : get_delta,
+                "units"      : "/s",
+                "description": "N regexps tested against",
+                }))
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'n_ban_dups',
+                "call_back"  : get_delta,
+                "units"      : "/s",
+                "description": "N duplicate bans removed",
+                }))
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'n_ban_add',
+                "call_back"  : get_delta,
+                "units"      : "/s",
+                "description": "N new bans added",
+                }))
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'n_ban_dups',
+                "call_back"  : get_delta,
+                "units"      : "/s",
+                "description": "N duplicate bans removed",
+                }))
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'n_ban_obj_test',
+                "call_back"  : get_delta,
+                "units"      : "/s",
+                "description": "N objects tested",
+                }))
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'n_ban_re_test',
+                "call_back"  : get_delta,
+                "units"      : "/s",
+                "description": "N regexps tested against",
+                }))
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'n_ban_retire',
+                "call_back"  : get_delta,
+                "units"      : "/s",
+                "description": "N old bans deleted",
+                }))
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'n_gunzip',
+                "call_back"  : get_delta,
+                "units"      : "/s",
+                "description": "Gunzip operations",
+                }))
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'n_gzip',
+                "call_back"  : get_delta,
+                "units"      : "/s",
+                "description": "Gzip operations",
+                }))
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'n_vbc',
+                "call_back"  : get_delta,
+                "units"      : "/s",
+                "description": "N struct vbc",
+                }))
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'n_waitinglist',
+                "call_back"  : get_delta,
+                "units"      : "/s",
+                "description": "N struct waitinglist",
+                }))
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'n_wrk_lqueue',
+                "call_back"  : get_value,
+                "units"      : "",
+                "description": "work request queue length",
+                }))
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'n_wrk_queued',
+                "call_back"  : get_value,
+                "units"      : "req",
+                "description": "N queued work requests",
+                }))
+    
+    descriptors.append( create_desc(Desc_Skel, {
+                "name"       : NAME_PREFIX + 'vmods',
+                "call_back"  : get_value,
+                "units"      : "vmods",
+                "description": "Loaded VMODs",
+                }))
+
+
 
     return descriptors
 

--- a/gmond/python_modules/varnish/varnish.py
+++ b/gmond/python_modules/varnish/varnish.py
@@ -40,18 +40,18 @@ import copy
 
 NAME_PREFIX = 'varnish_'
 PARAMS = {
-    'stats_command' : 'varnishstat -1'
+    'stats_command': 'varnishstat -1'
 }
 METRICS = {
-    'time' : 0,
-    'data' : {}
+    'time': 0,
+    'data': {}
 }
 LAST_METRICS = copy.deepcopy(METRICS)
 METRICS_CACHE_MAX = 5
 
 def create_desc(skel, prop):
     d = skel.copy()
-    for k,v in prop.iteritems():
+    for k, v in prop.iteritems():
         d[k] = v
     return d
 
@@ -89,7 +89,7 @@ def get_value(name):
 
     metrics = get_metrics()[0]
 
-    name = name[len(NAME_PREFIX):] # remove prefix from name
+    name = name[len(NAME_PREFIX):]  # remove prefix from name
     try:
         result = metrics['data'][name]
     except StandardError:
@@ -105,9 +105,9 @@ def get_delta(name):
     [curr_metrics, last_metrics] = get_metrics()
 
     # get delta
-    name = name[len(NAME_PREFIX):] # remove prefix from name
+    name = name[len(NAME_PREFIX):]  # remove prefix from name
     try:
-        delta = float(curr_metrics['data'][name] - last_metrics['data'][name])/(curr_metrics['time'] - last_metrics['time'])
+        delta = float(curr_metrics['data'][name] - last_metrics['data'][name]) / (curr_metrics['time'] - last_metrics['time'])
         if delta < 0:
             print "Less than 0"
             delta = 0
@@ -147,686 +147,686 @@ def metric_init(lparams):
         'value_type'  : 'float',
         'format'      : '%f',
         'units'       : 'XXX',
-        'slope'       : 'both', # zero|positive|negative|both
+        'slope'       : 'both',  # zero|positive|negative|both
         'description' : 'XXX',
         'groups'      : 'varnish',
         }
 
     descriptors = []
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'cache_hit_ratio',
                 "call_back"  : get_cache_hit_ratio,
                 "units"      : "pct",
                 "description": "Cache Hit ratio",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'client_conn',
                 "call_back"  : get_delta,
                 "units"      : "conn/s",
                 "description": "Client connections accepted",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'client_drop',
                 "call_back"  : get_delta,
                 "units"      : "conn/s",
                 "description": "Connection dropped, no sess/wrk",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'client_req',
                 "call_back"  : get_delta,
                 "units"      : "req/s",
                 "description": "Client requests received",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'cache_hit',
                 "call_back"  : get_delta,
                 "units"      : "hit/s",
                 "description": "Cache hits",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'cache_hitpass',
                 "call_back"  : get_delta,
                 "units"      : "hit/s",
                 "description": "Cache hits for pass",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'cache_miss',
                 "units"      : "miss/s",
                 "call_back"  : get_delta,
                 "description": "Cache misses",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'backend_conn',
                 "call_back"  : get_delta,
                 "units"      : "conn/s",
                 "description": "Backend conn. success",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'backend_unhealthy',
                 "call_back"  : get_delta,
                 "units"      : "conn/s",
                 "description": "Backend conn. not attempted",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'backend_busy',
                 "call_back"  : get_delta,
                 "units"      : "busy/s",
                 "description": "Backend conn. too many",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'backend_fail',
                 "call_back"  : get_delta,
                 "units"      : "fail/s",
                 "description": "Backend conn. failures",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'backend_reuse',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Backend conn. reuses",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'backend_toolate',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Backend conn. was closed",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'backend_recycle',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Backend conn. recycles",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'backend_unused',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Backend conn. unused",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'fetch_head',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Fetch head",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'fetch_length',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Fetch with Length",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'fetch_chunked',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Fetch chunked",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'fetch_eof',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Fetch EOF",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'fetch_bad',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Fetch had bad headers",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'fetch_close',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Fetch wanted close",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'fetch_oldhttp',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Fetch pre HTTP/1.1 closed",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'fetch_zero',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Fetch zero len",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'fetch_failed',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Fetch failed",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_sess_mem',
                 "call_back"  : get_value,
                 "units"      : "Bytes",
                 "description": "N struct sess_mem",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_sess',
                 "call_back"  : get_value,
                 "units"      : "sessions",
                 "description": "N struct sess",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_object',
                 "call_back"  : get_value,
                 "units"      : "objects",
                 "description": "N struct object",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_vampireobject',
                 "call_back"  : get_value,
                 "units"      : "objects",
                 "description": "N unresurrected objects",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_objectcore',
                 "call_back"  : get_value,
                 "units"      : "objects",
                 "description": "N struct objectcore",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_objecthead',
                 "call_back"  : get_value,
                 "units"      : "objects",
                 "description": "N struct objecthead",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_smf',
                 "call_back"  : get_value,
                 "units"      : "",
                 "description": "N struct smf",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_smf_frag',
                 "call_back"  : get_value,
                 "units"      : "frags",
                 "description": "N small free smf",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_smf_large',
                 "call_back"  : get_value,
                 "units"      : "frags",
                 "description": "N large free smf",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_vbe_conn',
                 "call_back"  : get_value,
                 "units"      : "conn",
                 "description": "N struct vbe_conn",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_wrk',
                 "call_back"  : get_value,
                 "units"      : "threads",
                 "description": "N worker threads",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_wrk_create',
                 "call_back"  : get_delta,
                 "units"      : "threads/s",
                 "description": "N worker threads created",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_wrk_failed',
                 "call_back"  : get_delta,
                 "units"      : "wrk/s",
                 "description": "N worker threads not created",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_wrk_max',
                 "call_back"  : get_delta,
                 "units"      : "threads/s",
                 "description": "N worker threads limited",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_wrk_queue',
                 "call_back"  : get_value,
                 "units"      : "req",
                 "description": "N queued work requests",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_wrk_overflow',
                 "call_back"  : get_delta,
                 "units"      : "req/s",
                 "description": "N overflowed work requests",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_wrk_drop',
                 "call_back"  : get_delta,
                 "units"      : "req/s",
                 "description": "N dropped work requests",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_backend',
                 "call_back"  : get_value,
                 "units"      : "backends",
                 "description": "N backends",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_expired',
                 "call_back"  : get_delta,
                 "units"      : "obj/s",
                 "description": "N expired objects",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_lru_nuked',
                 "call_back"  : get_delta,
                 "units"      : "obj/s",
                 "description": "N LRU nuked objects",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_lru_saved',
                 "call_back"  : get_delta,
                 "units"      : "obj/s",
                 "description": "N LRU saved objects",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_lru_moved',
                 "call_back"  : get_delta,
                 "units"      : "obj/s",
                 "description": "N LRU moved objects",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_deathrow',
                 "call_back"  : get_delta,
                 "units"      : "obj/s",
                 "description": "N objects on deathrow",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'losthdr',
                 "call_back"  : get_delta,
                 "units"      : "hdrs/s",
                 "description": "HTTP header overflows",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_objsendfile',
                 "call_back"  : get_delta,
                 "units"      : "obj/s",
                 "description": "Objects sent with sendfile",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_objwrite',
                 "call_back"  : get_delta,
                 "units"      : "obj/s",
                 "description": "Objects sent with write",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_objoverflow',
                 "call_back"  : get_delta,
                 "description": "Objects overflowing workspace",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 's_sess',
                 "call_back"  : get_delta,
                 "description": "Total Sessions",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 's_req',
                 "call_back"  : get_delta,
                 "description": "Total Requests",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 's_pipe',
                 "call_back"  : get_delta,
                 "description": "Total pipe",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 's_pass',
                 "call_back"  : get_delta,
                 "description": "Total pass",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 's_fetch',
                 "call_back"  : get_delta,
                 "description": "Total fetch",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 's_hdrbytes',
                 "call_back"  : get_delta,
                 "description": "Total header bytes",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 's_bodybytes',
                 "call_back"  : get_delta,
                 "units"      : "bytes/s",
                 "description": "Total body bytes",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sess_closed',
                 "call_back"  : get_delta,
                 "units"      : "sessions/s",
                 "description": "Session Closed",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sess_pipeline',
                 "call_back"  : get_delta,
                 "description": "Session Pipeline",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sess_readahead',
                 "call_back"  : get_delta,
                 "description": "Session Read Ahead",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sess_linger',
                 "call_back"  : get_delta,
                 "description": "Session Linger",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sess_herd',
                 "call_back"  : get_delta,
                 "description": "Session herd",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'shm_records',
                 "call_back"  : get_delta,
                 "description": "SHM records",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'shm_writes',
                 "call_back"  : get_delta,
                 "description": "SHM writes",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'shm_flushes',
                 "call_back"  : get_delta,
                 "description": "SHM flushes due to overflow",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'shm_cont',
                 "call_back"  : get_delta,
                 "description": "SHM MTX contention",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'shm_cycles',
                 "call_back"  : get_delta,
                 "description": "SHM cycles through buffer",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sm_nreq',
                 "call_back"  : get_delta,
                 "description": "allocator requests",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sm_nobj',
                 "call_back"  : get_delta,
                 "description": "outstanding allocations",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sm_balloc',
                 "call_back"  : get_value,
                 "description": "bytes allocated",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sm_bfree',
                 "call_back"  : get_delta,
                 "description": "bytes free",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sma_nreq',
                 "call_back"  : get_delta,
                 "description": "SMA allocator requests",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sma_nobj',
                 "call_back"  : get_value,
                 "units"      : "obj",
                 "description": "SMA outstanding allocations",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sma_nbytes',
                 "call_back"  : get_value,
                 "units"      : "Bytes",
                 "description": "SMA outstanding bytes",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sma_balloc',
                 "call_back"  : get_delta,
                 "units"      : "bytes/s",
                 "description": "SMA bytes allocated",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sma_bfree',
                 "call_back"  : get_delta,
                 "units"      : "bytes/s",
                 "description": "SMA bytes free",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sms_nreq',
                 "call_back"  : get_delta,
                 "units"      : "req/s",
                 "description": "SMS allocator requests",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sms_nobj',
                 "call_back"  : get_value,
                 "units"      : "obj",
                 "description": "SMS outstanding allocations",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sms_nbytes',
                 "call_back"  : get_value,
                 "units"      : "Bytes",
                 "description": "SMS outstanding bytes",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sms_balloc',
                 "call_back"  : get_delta,
                 "units"      : "bytes/s",
                 "description": "SMS bytes allocated",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sms_bfree',
                 "call_back"  : get_delta,
                 "units"      : "Bytes/s",
                 "description": "SMS bytes freed",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'backend_req',
                 "call_back"  : get_delta,
                 "units"      : "req/s",
                 "description": "Backend requests made",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_vcl',
                 "call_back"  : get_value,
                 "units"      : "vcl",
                 "description": "N vcl total",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_vcl_avail',
                 "call_back"  : get_value,
                 "units"      : "vcl",
                 "description": "N vcl available",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_vcl_discard',
                 "call_back"  : get_value,
                 "units"      : "vcl",
                 "description": "N vcl discarded",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_purge',
                 "call_back"  : get_value,
                 "units"      : "purges",
                 "description": "N total active purges",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_purge_add',
                 "call_back"  : get_delta,
                 "units"      : "purges/sec",
                 "description": "N new purges added",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_purge_retire',
                 "call_back"  : get_delta,
                 "units"      : "purges/s",
                 "description": "N old purges deleted",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_purge_obj_test',
                 "call_back"  : get_delta,
                 "units"      : "purges/s",
                 "description": "N objects tested",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_purge_re_test',
                 "call_back"  : get_delta,
                 "description": "N regexps tested against",
                 "units"      : "purges/s",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_purge_dups',
                 "call_back"  : get_delta,
                 "units"      : "purges/s",
                 "description": "N duplicate purges removed",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'hcb_nolock',
                 "call_back"  : get_delta,
                 "units"      : "locks/s",
                 "description": "HCB Lookups without lock",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'hcb_lock',
                 "call_back"  : get_delta,
                 "units"      : "locks/s",
                 "description": "HCB Lookups with lock",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'hcb_insert',
                 "call_back"  : get_delta,
                 "units"      : "inserts/s",
                 "description": "HCB Inserts",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'esi_parse',
                 "call_back"  : get_delta,
                 "units"      : "obj/s",
                 "description": "Objects ESI parsed (unlock)",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'esi_errors',
                 "call_back"  : get_delta,
                 "units"      : "err/s",
                 "description": "ESI parse errors (unlock)",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'accept_fail',
                 "call_back"  : get_delta,
                 "units"      : "accepts/s",
                 "description": "Accept failures",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'client_drop_late',
                 "call_back"  : get_delta,
                 "units"      : "conn/s",
                 "description": "Connection dropped late",
                 }))
 
-    descriptors.append( create_desc(Desc_Skel, {
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'uptime',
                 "call_back"  : get_value,
                 "units"      : "seconds",
@@ -834,198 +834,195 @@ def metric_init(lparams):
                 }))
 
     ##############################################################################
-    
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'backend_retry',
                 "call_back"  : get_delta,
                 "units"      : "retries/s",
                 "description": "Backend conn. retry",
                 }))
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'dir_dns_cache_full',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "DNS director full dnscache",
                 }))
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'dir_dns_failed',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "DNS director failed lookups",
                 }))
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'dir_dns_hit',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "DNS director cached lookups hit",
                 }))
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'dir_dns_lookups',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "DNS director lookups",
                 }))
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'esi_warnings',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "ESI parse warnings (unlock)",
                 }))
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'fetch_1xx',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Fetch no body (1xx)",
                 }))
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'fetch_204',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Fetch no body (204)",
                 }))
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'fetch_304',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Fetch no body (304)",
                 }))
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_ban',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "N total active bans",
                 }))
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_ban_add',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "N new bans added",
                 }))
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_ban_retire',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "N old bans deleted",
                 }))
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_ban_obj_test',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "N objects tested",
                 }))
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_ban_re_test',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "N regexps tested against",
                 }))
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_ban_dups',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "N duplicate bans removed",
                 }))
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_ban_add',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "N new bans added",
                 }))
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_ban_dups',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "N duplicate bans removed",
                 }))
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_ban_obj_test',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "N objects tested",
                 }))
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_ban_re_test',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "N regexps tested against",
                 }))
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_ban_retire',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "N old bans deleted",
                 }))
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_gunzip',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Gunzip operations",
                 }))
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_gzip',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Gzip operations",
                 }))
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_vbc',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "N struct vbc",
                 }))
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_waitinglist',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "N struct waitinglist",
                 }))
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_wrk_lqueue',
                 "call_back"  : get_value,
                 "units"      : "",
                 "description": "work request queue length",
                 }))
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_wrk_queued',
                 "call_back"  : get_value,
                 "units"      : "req",
                 "description": "N queued work requests",
                 }))
-    
-    descriptors.append( create_desc(Desc_Skel, {
+
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'vmods',
                 "call_back"  : get_value,
                 "units"      : "vmods",
                 "description": "Loaded VMODs",
                 }))
-
-
 
     return descriptors
 

--- a/gmond/python_modules/varnish/varnish.py
+++ b/gmond/python_modules/varnish/varnish.py
@@ -24,6 +24,15 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
+# This module parses output from the varnishstat command and creates "varnish_*"
+# metrics:
+#  * Client Requests per second
+#  * Backend Requests per second
+#  * Cache Hit Ratio
+#  * Objects in Cache
+#  * Allocated Storage
+#  * Worker Threads
+
 
 import os
 import time

--- a/gmond/python_modules/vm_stats/vm_stats.py
+++ b/gmond/python_modules/vm_stats/vm_stats.py
@@ -1,3 +1,8 @@
+# This module allows you to collect VM metrics.
+# are values that are collected from
+#
+# /proc/vmstat
+
 import sys
 import re
 import time

--- a/gmond/python_modules/vm_stats/vm_stats.py
+++ b/gmond/python_modules/vm_stats/vm_stats.py
@@ -13,8 +13,8 @@ PARAMS = {}
 NAME_PREFIX = 'vm_'
 
 METRICS = {
-    'time' : 0,
-    'data' : {}
+    'time': 0,
+    'data': {}
 }
 LAST_METRICS = copy.deepcopy(METRICS)
 METRICS_CACHE_MAX = 5
@@ -38,11 +38,11 @@ def get_metrics():
 
     if (time.time() - METRICS['time']) > METRICS_CACHE_MAX:
 
-	try:
-	    file = open(vminfo_file, 'r')
-    
-	except IOError:
-	    return 0
+        try:
+            file = open(vminfo_file, 'r')
+
+        except IOError:
+            return 0
 
         # convert to dict
         metrics = {}
@@ -59,12 +59,13 @@ def get_metrics():
 
     return [METRICS, LAST_METRICS]
 
+
 def get_value(name):
     """Return a value for the requested metric"""
 
     metrics = get_metrics()[0]
 
-    name = name[len(NAME_PREFIX):] # remove prefix from name
+    name = name[len(NAME_PREFIX):]  # remove prefix from name
 
     try:
         result = metrics['data'][name]
@@ -80,15 +81,15 @@ def get_delta(name):
     # get metrics
     [curr_metrics, last_metrics] = get_metrics()
 
-    name = name[len(NAME_PREFIX):] # remove prefix from name
+    name = name[len(NAME_PREFIX):]  # remove prefix from name
 
     try:
-      delta = (float(curr_metrics['data'][name]) - float(last_metrics['data'][name])) /(curr_metrics['time'] - last_metrics['time'])
-      if delta < 0:
-	print name + " is less 0"
-	delta = 0
+        delta = (float(curr_metrics['data'][name]) - float(last_metrics['data'][name])) / (curr_metrics['time'] - last_metrics['time'])
+        if delta < 0:
+            print name + " is less 0"
+            delta = 0
     except KeyError:
-      delta = 0.0      
+        delta = 0.0
 
     return delta
 
@@ -96,34 +97,35 @@ def get_delta(name):
 # Calculate VM efficiency
 # Works similar like sar -B 1
 # Calculated as pgsteal / pgscan, this is a metric of the efficiency of page reclaim. If  it  is  near  100%  then
-# almost  every  page coming off the tail of the inactive list is being reaped. If it gets too low (e.g. less than 30%)  
+# almost  every  page coming off the tail of the inactive list is being reaped. If it gets too low (e.g. less than 30%)
 # then the virtual memory is having some difficulty.  This field is displayed as zero if no pages  have  been
 # scanned during the interval of time
-def get_vmeff(name):  
+def get_vmeff(name):
     # get metrics
     [curr_metrics, last_metrics] = get_metrics()
-        
+
     try:
-      pgscan_diff = float(curr_metrics['data']['pgscan_kswapd_normal']) - float(last_metrics['data']['pgscan_kswapd_normal'])
-      # To avoid division by 0 errors check whether pgscan is 0
-      if pgscan_diff == 0:
-	return 0.0
-	
-      delta = 100 * (float(curr_metrics['data']['pgsteal_normal']) - float(last_metrics['data']['pgsteal_normal'])) / pgscan_diff
-      if delta < 0:
-        print name + " is less 0"
-        delta = 0
+        pgscan_diff = float(curr_metrics['data']['pgscan_kswapd_normal']) - float(last_metrics['data']['pgscan_kswapd_normal'])
+        # To avoid division by 0 errors check whether pgscan is 0
+        if pgscan_diff == 0:
+            return 0.0
+
+        delta = 100 * (float(curr_metrics['data']['pgsteal_normal']) - float(last_metrics['data']['pgsteal_normal'])) / pgscan_diff
+        if delta < 0:
+            print name + " is less 0"
+            delta = 0
     except KeyError:
-      delta = 0.0      
+        delta = 0.0
 
     return delta
-  
+
 
 def create_desc(skel, prop):
     d = skel.copy()
-    for k,v in prop.iteritems():
+    for k, v in prop.iteritems():
         d[k] = v
     return d
+
 
 def metric_init(params):
     global descriptors, metric_map, Desc_Skel
@@ -137,7 +139,7 @@ def metric_init(params):
         'value_type'  : 'float',
         'format'      : '%.4f',
         'units'       : 'count',
-        'slope'       : 'both', # zero|positive|negative|both
+        'slope'       : 'both',  # zero|positive|negative|both
         'description' : 'XXX',
         'groups'      : 'memory_vm',
         }
@@ -720,6 +722,7 @@ def metric_init(params):
                 }))
 
     return descriptors
+
 
 def metric_cleanup():
     '''Clean up the metric module.'''

--- a/gmond/python_modules/xen/xenstats.py
+++ b/gmond/python_modules/xen/xenstats.py
@@ -1,17 +1,17 @@
 #       xenstats.py
-#       
+#
 #       Copyright 2011 Marcos Amorim <marcosmamorim@gmail.com>
-#       
+#
 #       This program is free software; you can redistribute it and/or modify
 #       it under the terms of the GNU General Public License as published by
 #       the Free Software Foundation; either version 2 of the License, or
 #       (at your option) any later version.
-#       
+#
 #       This program is distributed in the hope that it will be useful,
 #       but WITHOUT ANY WARRANTY; without even the implied warranty of
 #       MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #       GNU General Public License for more details.
-#       
+#
 #       You should have received a copy of the GNU General Public License
 #       along with this program; if not, write to the Free Software
 #       Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
@@ -25,13 +25,15 @@ descriptors = list()
 conn        = libvirt.openReadOnly("xen:///")
 conn_info   = conn.getInfo()
 
+
 def xen_vms(name):
     '''Return number of virtual is running'''
     global conn
 
-    vm_count   = conn.numOfDomains()
+    vm_count = conn.numOfDomains()
 
     return vm_count
+
 
 def xen_mem(name):
     '''Return node memory '''
@@ -40,6 +42,7 @@ def xen_mem(name):
 
     # O xen retorna o valor da memoria em MB, vamos passar por KB
     return conn_info[1] * 1024
+
 
 def xen_cpu(name):
     '''Return numbers of CPU's'''
@@ -61,6 +64,7 @@ def xen_mem_use(name):
         vm_mem = vm_mem + info[2]
 
     return vm_mem
+
 
 def metric_init(params):
     global descriptors
@@ -108,9 +112,10 @@ def metric_init(params):
             'groups': 'xen'
             }
 
-    descriptors = [d1,d2,d3,d4]
+    descriptors = [d1, d2, d3, d4]
 
     return descriptors
+
 
 def metric_cleanup():
     '''Clean up the metric module.'''
@@ -124,4 +129,3 @@ if __name__ == '__main__':
     for d in descriptors:
         v = d['call_back'](d['name'])
         print 'value for %s is %u' % (d['name'],  v)
-


### PR DESCRIPTION
Historically python modules were spread between this repository and
`gmond_python_modules`.  At best this resulted in ad-hoc manual
syncing, at worst parallel and inconsistent development.  For the
already 'core' modules included in `monitoring-core`, treat this
repository as the canonical location.

Individual commits have additional details.  All of the python 'compiles', but there were judgement calls in the case of modules with parrallel development.