### PR TITLE
update old bugzilla bug report links to github

### DIFF
--- a/BUGS
+++ b/BUGS
@@ -1,4 +1,4 @@
-Report all bugs to the Ganglia Bugzilla Page at
+Report all bugs to the Ganglia Github project at
 
-  http://bugzilla.ganglia.info/cgi-bin/bugzilla/index.cgi
+  https://github.com/ganglia/monitor-core/issues
 

--- a/mans/gmetad.1
+++ b/mans/gmetad.1
@@ -30,9 +30,9 @@ Write process\-id to file
 .SH AUTHOR
 Matt Massie <massie@cs.berkeley.edu>
 .SH "REPORTING BUGS"
-Report all bugs to the Ganglia Bugzilla Page at
+Report all bugs to the Ganglia Github project at
 
-  http://bugzilla.ganglia.info/cgi-bin/bugzilla/index.cgi
+  https://github.com/ganglia/monitor-core/issues
 .SH COPYRIGHT
 Copyright (c) 2001, 2002, 2003, 2004, 2005 by 
 The Regents of the University of California.  All rights reserved.

--- a/mans/gmetric.1
+++ b/mans/gmetric.1
@@ -61,9 +61,9 @@ spoof a heartbeat message (use with spoof option)
 .SH AUTHOR
 Matt Massie <massie@cs.berkeley.edu>
 .SH "REPORTING BUGS"
-Report all bugs to the Ganglia Bugzilla Page at
+Report all bugs to the Ganglia Github project at
 
-  http://bugzilla.ganglia.info/cgi-bin/bugzilla/index.cgi
+  https://github.com/ganglia/monitor-core/issues
 .SH COPYRIGHT
 Copyright (c) 2001, 2002, 2003, 2004, 2005 by 
 The Regents of the University of California.  All rights reserved.

--- a/mans/gmond.1
+++ b/mans/gmond.1
@@ -52,9 +52,9 @@ Write process\-id to file
 .SH AUTHOR
 Matt Massie <massie@cs.berkeley.edu>
 .SH "REPORTING BUGS"
-Report all bugs to the Ganglia Bugzilla Page at
+Report all bugs to the Ganglia Github project at
 
-  http://bugzilla.ganglia.info/cgi-bin/bugzilla/index.cgi
+  https://github.com/ganglia/monitor-core/issues
 .SH COPYRIGHT
 Copyright (c) 2001, 2002, 2003, 2004, 2005 by 
 The Regents of the University of California.  All rights reserved.

--- a/mans/gstat.1
+++ b/mans/gstat.1
@@ -45,9 +45,9 @@ Specify the gmond port to query  (default=`8649')
 .SH AUTHOR
 Matt Massie <massie@cs.berkeley.edu>
 .SH "REPORTING BUGS"
-Report all bugs to the Ganglia Bugzilla Page at
+Report all bugs to the Ganglia Github project at
 
-  http://bugzilla.ganglia.info/cgi-bin/bugzilla/index.cgi
+  https://github.com/ganglia/monitor-core/issues
 .SH COPYRIGHT
 Copyright (c) 2001, 2002, 2003, 2004, 2005 by 
 The Regents of the University of California.  All rights reserved.


### PR DESCRIPTION
NOTE: These files have a 'DO NOT MODIFY THIS FILE' header, but they
appear to have been edited multiple times.  Notable runing `help2man`
today does not produce any `REPORTING BUGS` section.  There is
probably a more modern way to generate man pages that should be
considered in the future.

ML Ref: https://www.mail-archive.com/ganglia-developers%40lists.sourceforge.net/msg06496.html