### PR TITLE
remove stray reference to old variable

### DIFF
--- a/gmond/python_modules/apache_status/apache_status.py
+++ b/gmond/python_modules/apache_status/apache_status.py
@@ -386,7 +386,7 @@ def metric_init(params):
 
 def metric_cleanup():
     '''Clean up the metric module.'''
-    _Worker_Thread.shutdown()
+    pass
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`_Worker_Thread` was removed in:
 * 5eb4434d4bf4eb9d4ef83085dc445ef42249f152
 * ganglia/gmond_python_modules@b1a20da853cc4b8d9acfc787d6f3635a1a3a3f68

fix ganglia/gmond_python_modules#176