### PR TITLE
skip reading the stat files of processes that have exited.

### DIFF
--- a/gmond/python_modules/process/procstat.py
+++ b/gmond/python_modules/process/procstat.py
@@ -191,24 +191,30 @@ def get_pgroup(ppid, pgid):
     '''Return a list of pids having the same pgid, with the first in the list being the parent pid.'''
     logging.debug('getting pids for ppid/pgid: ' + ppid + '/' + pgid)
 
-    try:
-        # Get all processes in this group
-        p_list = []
-        for stat_file in glob.glob('/proc/[1-9]*/stat'):
+    # Get all processes in this group
+    p_list = []
+    for stat_file in glob.glob('/proc/[1-9]*/stat'):
+        try:
             stat = file(stat_file, 'rt').readline().split()
             if stat[4] == pgid:
                 p_list.append(stat[0])
+        except:
+            # likely the pid has exited. this is normal.
+            pass
 
-        # place pid at the top of the list
+    # place pid at the top of the list
+    if ppid in p_list:
         p_list.remove(ppid)
         p_list.insert(0, ppid)
+    else:
+        logging.warning('failed to find ppid ' + str(ppid) + ' in p_list')
 
-        logging.debug('p_list: ' + str(p_list))
+    logging.debug('p_list: ' + str(p_list))
 
-        return p_list
-
-    except:
+    if not len(p_list):
         logging.warning('failed getting pids')
+
+    return p_list
 
 
 def get_rss(pids):


### PR DESCRIPTION
there is a race between listing all the /proc/pid dirs and reading the
stat files in those dirs. try/except'ing each stat file individually
fixes this race.

there remains the corner case where the pid we are searching for is
one of those that has exited. this is detected and [] is returned.

this function's previous fall-through of returning None in case of any
problems was not understood by callers. this caused many errors in
abrt/syslog of the form
  [PYTHON] Can't call the metric handler function for [procstat_*_cpu] in the python module [procstat].
see eg.
  https://github.com/ganglia/gmond_python_modules/issues/114

by always returning [] in the worst case we solve that problem.