### PR TITLE
do not change the timestamp of a node upon receipt of spoofed data

### DIFF
--- a/gmond/gmond.c
+++ b/gmond/gmond.c
@@ -1120,7 +1120,9 @@ Ganglia_host_get( char *remIP, apr_sockaddr_t *sa, Ganglia_metric_id *metric_id)
   else
     {
       /* We already have this host in our "hosts" hash update timestamp */
-      hostdata->last_heard_from = apr_time_now();
+	if ( !metric_id->spoof ) {
+	    hostdata->last_heard_from = apr_time_now();
+	}
     }
 
   if (buff) free(buff);
@@ -1158,6 +1160,9 @@ Ganglia_update_vidals( Ganglia_host *host, Ganglia_value_msg *vmsg)
       {
         /* nothing more needs to be done. we handled the timestamps above. */
         host->gmond_started = vmsg->Ganglia_value_msg_u.gu_int.ui;
+	if(vmsg->Ganglia_value_msg_u.gstr.metric_id.spoof) {  // always true?
+	    host->last_heard_from = apr_time_now();
+	}
         debug_msg("Got a heartbeat message %d\n", host->gmond_started);
         /* Processing is finished */
       }
@@ -1424,7 +1429,9 @@ Ganglia_value_save( Ganglia_host *host, Ganglia_value_msg *message )
           break;
         }
 
-      metric->last_heard_from = apr_time_now();
+      if ( !message->Ganglia_value_msg_u.gstr.metric_id.spoof ) {
+	  metric->last_heard_from = apr_time_now();
+      }
 
       /* Save the last update metric */
       apr_thread_mutex_lock(host->mutex);


### PR DESCRIPTION
centrally collected out-of-band data (eg. from BMCs or a blade
chassis) which is then spoofed into the gmond network does not mean
that the node is actually up. unfortunately ganglia's notion of a node
being "up" is based upon the time when data was last received by the
gmond network - the "REPORTED" field in gmond's xml. fix this problem
by not updating the node's timestamp in gmond if the data source is
spoofed data.

users that wish to refresh a node's timestamp with spoofed data
(eg. if a node consists of only spoofed data) can use the -H option
to gmetric to explicitly send a heartbeat message and keep the node
in the "up" state.