### PR TITLE
fix apache_status.py whitespace regressing

### DIFF
--- a/gmond/python_modules/apache_status/apache_status.py
+++ b/gmond/python_modules/apache_status/apache_status.py
@@ -85,11 +85,11 @@ def get_metrics():
                 if long_metric_name == "Scoreboard":
                     for sck in split_line[1]:
                         metrics[ Scoreboard_bykey[sck] ] += 1
+                else:
+                    if long_metric_name in Metric_Map:
+                        metric_name = Metric_Map[long_metric_name]
                     else:
-                        if long_metric_name in Metric_Map:
-                            metric_name = Metric_Map[long_metric_name]
-                        else:
-                            metric_name = long_metric_name
+                        metric_name = long_metric_name
                     metrics[metric_name] = split_line[1]
 
         except urllib2.URLError:


### PR DESCRIPTION
91649c93d05cd6722033ae829d4cf18ec60b9ec2 introduced a regression when
cleaning up inconsistencies in whitespace.  An `else` block become
aligned with `for` instead of `if`.  This is unusual, but sadly
syntactically correct code.  This would cause some metrics, including
`ap_rps`, and `ap_busy_workers` to always report zeros.