### PR TITLE
Handle process names containing 1 or more underscores

### DIFF
--- a/gmond/python_modules/process/procstat.py
+++ b/gmond/python_modules/process/procstat.py
@@ -341,11 +341,9 @@ def get_stat(name):
 
     if ret:
         if name.startswith('procstat_'):
-            fir = name.find('_')
-            sec = name.find('_', fir + 1)
-
-            proc = name[fir + 1:sec]
-            label = name[sec + 1:]
+            nsp = name.split('_')
+            proc = '_'.join(nsp[1:-1])
+            label = nsp[-1]
 
             try:
                 return stats[proc][label]


### PR DESCRIPTION
This is to fix https://github.com/ganglia/gmond_python_modules/issues/156

This changes get_stat(name) to use split() to determine the process name and the label, rather than searching for the position of underscores.