### PR TITLE
Pass in correct slope enumeration value constructing root summary RRD.

### DIFF
--- a/gmetad/gmetad.c
+++ b/gmetad/gmetad.c
@@ -341,7 +341,8 @@ write_root_summary(datum_t *key, datum_t *val, void *arg)
 
    debug_msg("Writing Root Summary data for metric %s", name);
 
-   rc = write_data_to_rrd( NULL, NULL, name, sum, num, 15, 0, metric->slope);
+   rc = write_data_to_rrd( NULL, NULL, name, sum, num, 15, 0,
+      cstr_to_slope(getfield(metric->strings, metric->slope)));
    if (rc)
       {
          err_msg("Unable to write meta data for metric %s to RRD", name);


### PR DESCRIPTION
The write_root_summary function calls write_data_to_rrd, passing in
metric->slope for the slope parameter. However, metric->slope is a
string offset into the strings buffer and not a valid ganglia_slope_t
value. This results in an incorrectly constructed RRD, and many
warning messages emitted for every subsequent update.

The fix is to use cstr_to_slope() to translate the slope string into
a proper ganglia_slope_t value.
