### PR TITLE
Ignore hostname line in Apache 2.4.16

### DIFF
--- a/gmond/python_modules/apache_status/apache_status.py
+++ b/gmond/python_modules/apache_status/apache_status.py
@@ -86,6 +86,10 @@ def get_metrics():
                     for sck in split_line[1]:
                         metrics[ Scoreboard_bykey[sck] ] += 1
                 else:
+                    # Apache > 2.4.16 inserts the hostname as the first line, so ignore
+                    if len(split_line) == 1:
+                        continue
+                    
                     if long_metric_name in Metric_Map:
                         metric_name = Metric_Map[long_metric_name]
                     else:


### PR DESCRIPTION
https://github.com/apache/httpd/commit/f89436eac5ff5874efabeba01c3e75a90839b73a#diff-a25f910604a349cd1173529f96b0571eR431 adds the hostname as the first line on the mod_status output. This breaks ganglia at the moment as it's expecting each line to have a ": " separating key and values.