### PR TITLE
can't build on OpenBSD 5.7 without this

### DIFF
--- a/libmetrics/openbsd/metrics.c
+++ b/libmetrics/openbsd/metrics.c
@@ -21,6 +21,7 @@
 #include <sys/swap.h>
 #include <uvm/uvm_param.h>
 #include <sys/proc.h>
+#include <sys/vmmeter.h>
 
 #include <sys/socket.h>
 #include <net/if.h>


### PR DESCRIPTION
Some header changes happened somewhere and now this has to be specified manually.