### PR TITLE
add bytes_sum metric

### DIFF
--- a/gmond/modules/network/mod_net.c
+++ b/gmond/modules/network/mod_net.c
@@ -43,6 +43,9 @@ static g_val_t net_metric_handler ( int metric_index )
     case 3:
         return pkts_out_func();
     }
+    case 4:
+        val.f = bytes_out_func().f+bytes_in_func().f;
+        return val;
 
     /* default case */
     val.f = 0;
@@ -55,6 +58,7 @@ static Ganglia_25metric net_metric_info[] =
     {0, "bytes_in",   300, GANGLIA_VALUE_FLOAT,  "bytes/sec",   "both", "%.2f", UDP_HEADER_SIZE+8,  "Number of bytes in per second"},
     {0, "pkts_in",    300, GANGLIA_VALUE_FLOAT,  "packets/sec", "both", "%.2f", UDP_HEADER_SIZE+8,  "Packets in per second"},
     {0, "pkts_out",   300, GANGLIA_VALUE_FLOAT,  "packets/sec", "both", "%.2f", UDP_HEADER_SIZE+8,  "Packets out per second"},
+    {0, "bytes_sum",   300, GANGLIA_VALUE_FLOAT,  "bytes/sec", "both", "%.2f", UDP_HEADER_SIZE+8,  "Number of bytes sum  per second"},
     {0, NULL}
 };
 


### PR DESCRIPTION
we can add the following in the gmod.conf to call it
###
 metric {
    name = "bytes_sum"
    value_threshold = 4096
    title = "Bytes Sum"      
  } 
###

![bytes_sum](https://cloud.githubusercontent.com/assets/5434158/9980950/727e921a-5fdf-11e5-9044-733ab3c7fb05.jpg)
