### PR TITLE
Avoid KeyError for new metric groups.

### DIFF
--- a/gmond/python_modules/network/netstats.py
+++ b/gmond/python_modules/network/netstats.py
@@ -46,6 +46,8 @@ def get_metrics():
                     count = 0
                     metrics = re.split("\s+", line)
                     metric_group = metrics[0].replace(":", "").lower()
+                    if metric_group not in stats_pos:
+                        continue
                     new_metrics[metric_group] = dict()
                     for value in metrics:
                         # Skip first


### PR DESCRIPTION
If a metric group shows up in the network file sometime after initial
module startup, a KeyError may occur in get_metrics.  This causes the
netstats module to be non-functional until gmond is restarted.

Particularly, the IcmpMsg group will not be present until the first
IcmpMsg has been processed.

NOTE: I found this by dragging gmond through gdb.  It seems that the python exceptions / tracebacks aren't logged.  :(