### PR TITLE
Fix race condition - invalid metric send to carbon server

### DIFF
--- a/gmetad/gmetad.c
+++ b/gmetad/gmetad.c
@@ -610,11 +610,11 @@ main ( int argc, char *argv[] )
          /* Sum the new values */
          hash_foreach(root.authority, do_root_summary, NULL );
 
-         /* summary completed */
-         pthread_mutex_unlock(root.sum_finished);
-
          /* Save them to RRD */
          hash_foreach(root.metric_summary, write_root_summary, NULL);
+
+         /* summary completed */
+         pthread_mutex_unlock(root.sum_finished);
 
          /* Remember our last run */
          now = apr_time_now();


### PR DESCRIPTION
Fix race condition where new metrics are added while old metric still gets send
to carbon server. The carbon log is reporting invalid metrics.
This minor change does solve the issue.