### PR TITLE
Ignore files:  tags, *.m4, *.swp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ libmetrics/**/*.lo
 libmetrics/**/*.o
 libtool
 .idea
+**/tags
+**/*.m4
+**/*.swp


### PR DESCRIPTION
This adds a few transient files to the git ignore list--should clean up the "git status" output when actively developing things.