### PR TITLE
Remove trailing space in default gmond.conf header file

### DIFF
--- a/gmond/g25_config.c
+++ b/gmond/g25_config.c
@@ -373,5 +373,6 @@ print_ganglia_25_config( char *path )
    dotconf_cleanup(configfile);
 
    print_config(path, &gmond_config);
+   fclose(fp);
    return 0;
 }

--- a/lib/default_conf.h.in
+++ b/lib/default_conf.h.in
@@ -71,7 +71,7 @@ udp_recv_channel {\n\
   bind = 239.2.11.71\n\
   retry_bind = true\n\
   # Size of the UDP buffer. If you are handling lots of metrics you really\n\
-  # should bump it up to e.g. 10MB or even higher.\n\ 
+  # should bump it up to e.g. 10MB or even higher.\n\
   # buffer = 10485760\n\
 }\n\
 \n\


### PR DESCRIPTION
Simple patch to remove a trailing space in default_conf.h.in.