### PR TITLE
Report mem as float, to avoid uint32 overflow

### DIFF
--- a/gmond/python_modules/process/procstat.py
+++ b/gmond/python_modules/process/procstat.py
@@ -383,6 +383,8 @@ def metric_init(params):
 
         mem = {
             'units': 'B',
+            'value_type': 'float',
+            'format': '%.0f',
             'description': 'The total memory utilization'}
     )
 


### PR DESCRIPTION
Fixes #260.