### PR TITLE
The way forward is sometimes the way back

### DIFF
--- a/gmetad/gmetad.c
+++ b/gmetad/gmetad.c
@@ -323,7 +323,7 @@ write_root_summary(datum_t *key, datum_t *val, void *arg)
        return 0;
 
    /* Don't write a summary for metris that appears to be sFlow VM metrics */
-   if (gmetad_config.unsummarized_sflow_vm_metrics && (p = strchr(name, '.')) != NULL && *(p+1) == 'v')
+   if (gmetad_config.unsummarized_sflow_vm_metrics && (p = strrchr(name, '.')) != NULL && *(p+1) == 'v')
      return 0;
 
    ganglia_scoreboard_inc(METS_SUMRZ_ROOT);

--- a/gmetad/process_xml.c
+++ b/gmetad/process_xml.c
@@ -1172,7 +1172,7 @@ finish_processing_source(datum_t *key, datum_t *val, void *arg)
       return 0;
 
    /* Don't save to RRD if this metrics appears to be an sFlow VM metrics */
-   if (gmetad_config.unsummarized_sflow_vm_metrics && (p = strchr(name, '.')) != NULL && *(p+1) == 'v')
+   if (gmetad_config.unsummarized_sflow_vm_metrics && (p = strrchr(name, '.')) != NULL && *(p+1) == 'v')
        return 0;
 
    switch (tt->type)


### PR DESCRIPTION
RE: c8ca8bc68fae775d588aeef8e35db3f9255b48c3

The assumption that the sflow vm metric will always be of the form
name.vcpu_num is incorrect for environments where the virt name is the
fqdn.