### PR TITLE
Fix wrong steal values being reported for multi_cpu

### DIFF
--- a/gmond/modules/cpu/mod_multicpu.c
+++ b/gmond/modules/cpu/mod_multicpu.c
@@ -457,7 +457,7 @@ static cpu_util *init_metric (apr_pool_t *p, apr_array_header_t *ar, int cpu_cou
 static g_val_t multi_cpu_steal_func (int cpu_index)
 {
     char *p;
-    cpu_util *cpu = &(cpu_user[cpu_index]);
+    cpu_util *cpu = &(cpu_steal[cpu_index]);
 
     p = update_file(&proc_stat);
     if((proc_stat.last_read.tv_sec != cpu->stamp.tv_sec) &&


### PR DESCRIPTION
Due to a copy/paste error in a3833fa42cc8b5bca75d8c1e78baec643cfadf53,
the wrong values (user cpu) were being used for steal cpu comparisons.