### PR TITLE
issue 266, requiring dhcp and network interfaces to be UP

### DIFF
--- a/gmetad-python/gmetad-python.service.in
+++ b/gmetad-python/gmetad-python.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=Ganglia Meta Daemon in Python
-After=network.target
+After=network-online.target
 
 [Service]
 ExecStart=@bindir@/gmetad.py -f

--- a/gmetad/gmetad.service.in
+++ b/gmetad/gmetad.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=Ganglia Meta Daemon
-After=network.target
+After=network-online.target
 
 [Service]
 Type=forking

--- a/gmond/gmond.service.in
+++ b/gmond/gmond.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=Ganglia Monitor Daemon
-After=network.target
+After=network-online.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
Having only network waits for the interfaces to be present.

Specifying network-online means to wait until the interfaces are configured, in the case of dhcp, wait until a lease is given and network is up before bringing this service online.

https://baptiste-wicht.com/posts/2014/10/linux-tip-force-systemd-networkd-to-wait-for-dhcp.html