### PR TITLE
Fix issue 293

### DIFF
--- a/lib/hash.c
+++ b/lib/hash.c
@@ -346,6 +346,10 @@ hash_delete (datum_t *key, hash_t * hash)
   for (; bucket != NULL; last = bucket, bucket = bucket->next)
     {
       node_t tmp;
+      if (bucket->key && !hash_keycmp(hash, key, bucket->key))
+        {
+          continue;
+        }
       if (bucket == &hash->node[i]) 
         {
           tmp.key = bucket->key;


### PR DESCRIPTION
## Description
* Fix gmetad segmentation fault
* Relates to #293
* I think this commit removed hash key check, so hash_delete() always removes first bucket
  * https://github.com/ganglia/monitor-core/commit/02524bf2f5485cfd4cddb66bd3280e5a08a2232c#diff-b06f83698bd50e05e13870bc05676cc0L369

## Steps to reproduce
### simple example
* https://gist.github.com/junichi-tanaka/554f6b94c8ef722e11931f596c675a7f#file-test-c

### actual
```
$ ./test
172.16.1.56
```

### expected
```
$ ./test
172.16.1.1
```

### find hash collisions in gmetad
* https://gist.github.com/junichi-tanaka/19a14cb1d3b1820d61dbecae82ff9040