### PR TITLE
 Add Slab memory to linux-specific memory metrics

### DIFF
--- a/ganglia.pod
+++ b/ganglia.pod
@@ -609,6 +609,7 @@ is only partially complete).
   mem_cached    Amount of cached memory                  l,f
   mem_free      Amount of available memory               l,f
   mem_shared    Amount of shared memory                  l,f
+  mem_slab      Amount of in-kernel data struct cache    l
   mem_sreclaimable    Amount of slab reclaimable memory  l (kernel >= 2.6.19)
   mem_total     Amount of available memory               l,f
   mtu           Network maximum transmission unit        l,f

--- a/gmetad/server.c
+++ b/gmetad/server.c
@@ -119,6 +119,8 @@ static const struct metricinfo
   #ifdef LINUX
   "mem_sreclaimable", mem_sreclaimable_func, g_float},
   {
+  "mem_slab", mem_slab_func, g_float},
+  {
   #endif
   #ifdef SOLARIS
   "bread_sec", bread_sec_func, g_float},
@@ -894,7 +896,8 @@ status_report( client_t *client , char *callback)
          systemOffset += snprintf (systemBuf + systemOffset, METRICSBUFSIZE > systemOffset ? METRICSBUFSIZE - systemOffset : 0, "\"%s\":%u,", metrics[i].name, (unsigned) val.uint32);
       }
 #ifdef LINUX
-      else if(strcmp(metrics[i].name, "mem_sreclaimable") == 0){
+      else if(strcmp(metrics[i].name, "mem_slab") == 0 ||
+              strcmp(metrics[i].name, "mem_sreclaimable") == 0){
          memoryOffset += snprintf (memoryBuf + memoryOffset, METRICSBUFSIZE > memoryOffset ? METRICSBUFSIZE - memoryOffset : 0, "\"%s\":%f,", metrics[i].name, val.f);
       }
 #endif

--- a/gmond/modules/memory/mod_mem.c
+++ b/gmond/modules/memory/mod_mem.c
@@ -50,6 +50,8 @@ static g_val_t mem_metric_handler ( int metric_index )
 #ifdef LINUX
     case 7:
         return mem_sreclaimable_func();
+    case 8:
+        return mem_slab_func();
 #endif
 #if HPUX
     case 7:
@@ -79,6 +81,7 @@ static Ganglia_25metric mem_metric_info[] =
     {0, "swap_total", 1200, GANGLIA_VALUE_FLOAT, "KB", "zero", "%.0f", UDP_HEADER_SIZE+8, "Total amount of swap space displayed in KBs"},
 #ifdef LINUX
     {0, "mem_sreclaimable", 180, GANGLIA_VALUE_FLOAT, "KB", "both", "%.0f", UDP_HEADER_SIZE+8, "Amount of reclaimable slab memory"},
+    {0, "mem_slab",    180, GANGLIA_VALUE_FLOAT, "KB", "both", "%.0f", UDP_HEADER_SIZE+8, "Amount of in-kernel data structures cache"},
 #endif
 #if HPUX
     {0, "mem_arm",     180, GANGLIA_VALUE_FLOAT, "KB", "both", "%.0f", UDP_HEADER_SIZE+8, "mem_arm"},

--- a/lib/default_conf.h.in
+++ b/lib/default_conf.h.in
@@ -410,6 +410,19 @@ include (\"" SYSCONFDIR "/conf.d/*.conf\")\n\
 \n\
 "
 
+#define LINUX_SPECIFIC_CONFIGURATION "\
+collection_group {\n\
+  collect_every = 40\n\
+  time_threshold = 180\n\
+  metric {\n\
+    name = \"mem_slab\"\n\
+    value_threshold = \"1024.0\"\n\
+    title = \"Slab Memory\"\n\
+  }\n\
+}\n\
+\n\
+"
+
 #define SOLARIS_SPECIFIC_CONFIGURATION "\
 /* solaris specific metrics begin */\n\
 collection_group {\n\

--- a/lib/libgmond.c
+++ b/lib/libgmond.c
@@ -210,6 +210,9 @@ build_default_gmond_configuration(Ganglia_pool p)
   default_gmond_configuration = apr_pstrcat(context, default_gmond_configuration, SFLOW_CONFIGURATION, NULL);
 #endif
   default_gmond_configuration = apr_pstrcat(context, default_gmond_configuration, COLLECTION_GROUP_LIST, NULL);
+#if LINUX
+  default_gmond_configuration = apr_pstrcat(context, default_gmond_configuration, LINUX_SPECIFIC_CONFIGURATION, NULL);
+#endif
 #if SOLARIS
   default_gmond_configuration = apr_pstrcat(context, default_gmond_configuration, SOLARIS_SPECIFIC_CONFIGURATION, NULL);
 #endif

--- a/libmetrics/libmetrics.h
+++ b/libmetrics/libmetrics.h
@@ -79,7 +79,9 @@ void libmetrics_init( void );
  g_val_t location_func(void);
 
 #ifdef LINUX
+ g_val_t mem_slab_func (void);
  g_val_t mem_sreclaimable_func (void);
+ g_val_t mem_sunreclaim_func (void);
 #endif
 
 /* the following are additional internal metrics added by swagner

--- a/libmetrics/linux/metrics.c
+++ b/libmetrics/linux/metrics.c
@@ -1294,12 +1294,46 @@ mem_buffers_func ( void )
 }
 
 g_val_t
+mem_slab_func ( void )
+{
+   char *p;
+   g_val_t val;
+
+   p = strstr( update_file(&proc_meminfo), "Slab:" );
+   if(p) {
+     p = skip_token(p);
+     val.f = atof( p );
+   } else {
+     val.f = 0;
+   }
+
+   return val;
+}
+
+g_val_t
 mem_sreclaimable_func ( void )
 {
    char *p;
    g_val_t val;
 
    p = strstr( update_file(&proc_meminfo), "SReclaimable:" );
+   if(p) {
+     p = skip_token(p);
+     val.f = atof( p );
+   } else {
+     val.f = 0;
+   }
+
+   return val;
+}
+
+g_val_t
+mem_sunreclaim_func ( void )
+{
+   char *p;
+   g_val_t val;
+
+   p = strstr( update_file(&proc_meminfo), "SUnreclaim:" );
    if(p) {
      p = skip_token(p);
      val.f = atof( p );


### PR DESCRIPTION
According to later versions of procps, the top(1) value for "buff/cache"
memory is supposed in addition to Buffers/Cached to also include Slab.

Interestingly, the biggest impact of this is in the "used" memory shown
since that value is not reported but just calculated using the others:

``` C
// {"Cached",       &kb_page_cache},
kb_main_cached = kb_page_cache + kb_slab;
kb_swap_used = kb_swap_total - kb_swap_free;
kb_main_used = kb_main_total - kb_main_free - kb_main_cached - kb_main_buffers;

```
In order to have more accurate memory reporting on Linux, make sure to
include this metric in the default configuration for the memory module.