### PR TITLE
Use only the reclaimable Slab memory by default

### DIFF
--- a/gmetad/server.c
+++ b/gmetad/server.c
@@ -119,8 +119,6 @@ static const struct metricinfo
   #ifdef LINUX
   "mem_sreclaimable", mem_sreclaimable_func, g_float},
   {
-  "mem_slab", mem_slab_func, g_float},
-  {
   #endif
   #ifdef SOLARIS
   "bread_sec", bread_sec_func, g_float},
@@ -896,8 +894,7 @@ status_report( client_t *client , char *callback)
          systemOffset += snprintf (systemBuf + systemOffset, METRICSBUFSIZE > systemOffset ? METRICSBUFSIZE - systemOffset : 0, "\"%s\":%u,", metrics[i].name, (unsigned) val.uint32);
       }
 #ifdef LINUX
-      else if(strcmp(metrics[i].name, "mem_slab") == 0 ||
-              strcmp(metrics[i].name, "mem_sreclaimable") == 0){
+      else if(strcmp(metrics[i].name, "mem_sreclaimable") == 0){
          memoryOffset += snprintf (memoryBuf + memoryOffset, METRICSBUFSIZE > memoryOffset ? METRICSBUFSIZE - memoryOffset : 0, "\"%s\":%f,", metrics[i].name, val.f);
       }
 #endif

--- a/lib/default_conf.h.in
+++ b/lib/default_conf.h.in
@@ -415,9 +415,9 @@ collection_group {\n\
   collect_every = 40\n\
   time_threshold = 180\n\
   metric {\n\
-    name = \"mem_slab\"\n\
+    name = \"mem_sreclaimable\"\n\
     value_threshold = \"1024.0\"\n\
-    title = \"Slab Memory\"\n\
+    title = \"Slab Memory Reclaimable\"\n\
   }\n\
 }\n\
 \n\


### PR DESCRIPTION
Previously we would export Slab, but it should have been SReclaimable.
This is because we normally use the metric to estimate the memory Use.

* https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=565518
* https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=799716