### PR TITLE
Also add mem_available, to further improve stats

### DIFF
--- a/ganglia.pod
+++ b/ganglia.pod
@@ -607,11 +607,12 @@ is only partially complete).
   machine_type
   mem_buffers   Amount of buffered memory                l,f
   mem_cached    Amount of cached memory                  l,f
-  mem_free      Amount of available memory               l,f
+  mem_free      Amount of free memory available          l,f
   mem_shared    Amount of shared memory                  l,f
   mem_slab      Amount of in-kernel data struct cache    l
   mem_sreclaimable    Amount of slab reclaimable memory  l (kernel >= 2.6.19)
-  mem_total     Amount of available memory               l,f
+  mem_available Amount of application memory available   l (kernel >= 3.14)
+  mem_total     Amount of total memory available         l,f
   mtu           Network maximum transmission unit        l,f
   os_name       Operating system name                    l,f
   os_release    Operating system release (version)       l,f

--- a/gmetad/server.c
+++ b/gmetad/server.c
@@ -119,6 +119,10 @@ static const struct metricinfo
   #ifdef LINUX
   "mem_sreclaimable", mem_sreclaimable_func, g_float},
   {
+  "mem_slab", mem_slab_func, g_float},
+  {
+  "mem_available", mem_available_func, g_float},
+  {
   #endif
   #ifdef SOLARIS
   "bread_sec", bread_sec_func, g_float},

--- a/gmond/modules/memory/mod_mem.c
+++ b/gmond/modules/memory/mod_mem.c
@@ -52,6 +52,8 @@ static g_val_t mem_metric_handler ( int metric_index )
         return mem_sreclaimable_func();
     case 8:
         return mem_slab_func();
+    case 9:
+        return mem_available_func();
 #endif
 #if HPUX
     case 7:
@@ -82,6 +84,7 @@ static Ganglia_25metric mem_metric_info[] =
 #ifdef LINUX
     {0, "mem_sreclaimable", 180, GANGLIA_VALUE_FLOAT, "KB", "both", "%.0f", UDP_HEADER_SIZE+8, "Amount of reclaimable slab memory"},
     {0, "mem_slab",    180, GANGLIA_VALUE_FLOAT, "KB", "both", "%.0f", UDP_HEADER_SIZE+8, "Amount of in-kernel data structures cache"},
+    {0, "mem_available",    180, GANGLIA_VALUE_FLOAT, "KB", "both", "%.0f", UDP_HEADER_SIZE+8, "Estimate of how much memory is available"},
 #endif
 #if HPUX
     {0, "mem_arm",     180, GANGLIA_VALUE_FLOAT, "KB", "both", "%.0f", UDP_HEADER_SIZE+8, "mem_arm"},

--- a/lib/default_conf.h.in
+++ b/lib/default_conf.h.in
@@ -415,6 +415,11 @@ collection_group {\n\
   collect_every = 40\n\
   time_threshold = 180\n\
   metric {\n\
+    name = \"mem_available\"\n\
+    value_threshold = \"1024.0\"\n\
+    title = \"Available Memory\"\n\
+  }\n\
+  metric {\n\
     name = \"mem_sreclaimable\"\n\
     value_threshold = \"1024.0\"\n\
     title = \"Slab Memory Reclaimable\"\n\

--- a/libmetrics/libmetrics.h
+++ b/libmetrics/libmetrics.h
@@ -79,6 +79,7 @@ void libmetrics_init( void );
  g_val_t location_func(void);
 
 #ifdef LINUX
+ g_val_t mem_available_func (void);
  g_val_t mem_slab_func (void);
  g_val_t mem_sreclaimable_func (void);
  g_val_t mem_sunreclaim_func (void);

--- a/libmetrics/linux/metrics.c
+++ b/libmetrics/linux/metrics.c
@@ -1248,6 +1248,23 @@ mem_free_func ( void )
 }
 
 g_val_t
+mem_available_func ( void )
+{
+   char *p;
+   g_val_t val;
+
+   p = strstr( update_file(&proc_meminfo), "MemAvailable:" );
+   if (p) {
+     p = skip_token(p);
+     val.f = atof( p );
+   } else {
+     val.f = 0.0;
+   }
+
+   return val;
+}
+
+g_val_t
 mem_shared_func ( void )
 {
    char *p;


### PR DESCRIPTION
Recent versions of Linux gave up on trying to explain the various
types of memory, and added an explicit "MemAvailable" proc field.

Where available ;-), report this value since it can make the memory
graph even better - somewhat similar to load_one and proc_run...