### PR TITLE
Mitigation of "Incorrect format for spoof argument. exiting." errors

### DIFF
--- a/lib/libgmond.c
+++ b/lib/libgmond.c
@@ -26,7 +26,11 @@
 #include <dirent.h>
 #include <fnmatch.h>
 
-static char myhost[APRMAXHOSTLEN+1];
+/* functions throughout this file will initialize this
+ * variable if myhost[0] == '\0', so ensure the compiler
+ * initializes it as an empty string:
+ */
+static char myhost[APRMAXHOSTLEN+1] = "";
 
 /***** IMPORTANT ************
 Any changes that you make to this file need to be reconciled in ./conf.pod


### PR DESCRIPTION
**Symptom**:  gmond emits the following error message when configured with host spoofing

```
Incorrect format for spoof argument. exiting.
```

**Mitigation**: allocation of spoofed host id on cached metadata objects must be from the global pool and NOT a temporary pool.

**Secondary fixes**:

1. Guard against zero-length host ids in Ganglia_host_get()
2. Initialize global "myhost" character array to empty string to match expected pre-condition throughout libgmond.c