### PR TITLE
Handle NVMe devices correctly in diskstat.py

### DIFF
--- a/gmond/python_modules/disk/diskstat.py
+++ b/gmond/python_modules/disk/diskstat.py
@@ -197,7 +197,8 @@ def get_partitions():
                 continue
             device_name = line.split()[3]
             device_ends_with_number = re.search('\d$', device_name)
-            if 'md' in device_name or not device_ends_with_number:
+            nvme_device = re.search('^nvme\dn1$', device_name)
+            if 'md' in device_name or nvme_device or not device_ends_with_number:
                 # only include md devices and base block devices
                 devices.append(device_name)
         out = ' '.join(devices)


### PR DESCRIPTION
NVMe device names in AWS EC2 instances end with a digit `/dev/nvme[0-26]n1` (see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html).
This PR adds correct handling of NVMe devices in `diskstat` Python module. Otherwise, NVMe disks get ignored and metrics are not collected.