### PR TITLE
Removing the master/slave terminology

### DIFF
--- a/gmond/python_modules/db/redis.py
+++ b/gmond/python_modules/db/redis.py
@@ -55,7 +55,7 @@ def metric_handler(name):
                   continue
               n, v = line.split(":")
               if n in metric_handler.descriptors:
-                  if n == "master_sync_status":
+                  if n == "main_sync_status":
                       v = 1 if v == 'up' else 0
                   if n == "db0":
                       v = v.split('=')[1].split(',')[0]
@@ -102,13 +102,13 @@ def metric_init(params={}):
     metric_handler.prev_total_connections = 0
     metrics = {
         "connected_clients": {"units": "clients"},
-        "connected_slaves": {"units": "slaves"},
+        "connected_subordinates": {"units": "subordinates"},
         "blocked_clients": {"units": "clients"},
         "used_memory": {"units": "KB"},
         "rdb_changes_since_last_save": {"units": "changes"},
         "rdb_bgsave_in_progress": {"units": "yes/no"},
-        "master_sync_in_progress": {"units": "yes/no"},
-        "master_link_status": {"units": "yes/no"},
+        "main_sync_in_progress": {"units": "yes/no"},
+        "main_link_status": {"units": "yes/no"},
         #"aof_bgrewriteaof_in_progress": {"units": "yes/no"},
         "total_connections_received": {"units": "connections/sec"},
         "instantaneous_ops_per_sec": {"units": "ops"},
@@ -117,7 +117,7 @@ def metric_init(params={}):
         "pubsub_channels": {"units": "channels"},
         "pubsub_patterns": {"units": "patterns"},
         #"vm_enabled": {"units": "yes/no"},
-        "master_last_io_seconds_ago": {"units": "seconds ago"},
+        "main_last_io_seconds_ago": {"units": "seconds ago"},
         "db0": {"units": "keys"},
     }
     metric_handler.descriptors = {}

--- a/gmond/python_modules/process/procstat.py
+++ b/gmond/python_modules/process/procstat.py
@@ -68,12 +68,12 @@
 ###  Example Values:
 ###    httpd:      /var/run/httpd.pid or \/usr\/sbin\/httpd
 ###    mysqld:     /var/run/mysqld/mysqld.pid or /\/usr\/bin\/mysqld_safe/
-###    postgresql: /var/run/postmaster.[port].pid or /\/usr\/bin\/postmaster.*[port]/
+###    postgresql: /var/run/postmain.[port].pid or /\/usr\/bin\/postmain.*[port]/
 ###    splunk:     /splunkd.*start/
 ###    splunk-web: /twistd.*SplunkWeb/
 ###    opennms:    /opt/opennms/logs/daemon/opennms.pid or java.*Dopennms
 ###    netflow:    /java.*NetFlow/
-###    postfix:    /var/spool/postfix/pid/master.pid or /\/usr\/libexec\/postfix\/master/
+###    postfix:    /var/spool/postfix/pid/main.pid or /\/usr\/libexec\/postfix\/main/
 ###
 ###  Error Tests:
 ###    python procstat.py -p test-more,test-none,test-pidfail -v '/java/','/javaw/','java.pid' -t


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.