### PR TITLE
docs: fix simple typo, statstics -> statistics

### DIFF
--- a/libmetrics/darwin/metrics.c
+++ b/libmetrics/darwin/metrics.c
@@ -37,7 +37,7 @@
 #include <sys/socket.h>
 #include <stdio.h>
 
-/* Added for disk statstics */
+/* Added for disk statistics */
 #include <sys/param.h>
 #include <sys/ucred.h>
 #include <sys/mount.h>


### PR DESCRIPTION
There is a small typo in libmetrics/darwin/metrics.c.

Should read `statistics` rather than `statstics`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md