### PR TITLE
fixes for trixie

### DIFF
--- a/gmond/gmond.c
+++ b/gmond/gmond.c
@@ -1689,14 +1689,17 @@ socket_flush( apr_socket_t *client, int gzip_output )
   return APR_SUCCESS;
 }
 
-static void
-zstream_destroy( z_stream *strm )
+
+static apr_status_t
+zstream_destroy( void *data )
 {
+  z_stream *strm = (z_stream *)data;
   if (strm)
     {
       deflateEnd(strm);
       free (strm);
     }
+  return APR_SUCCESS;
 }
 
 static apr_status_t

--- a/systemd/gmond.service
+++ b/systemd/gmond.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Ganglia Monitor Daemon
+Documentation=man:gmond(1)
+After=network. target
+
+[Service]
+Type=forking
+PIDFile=/run/gmond.pid
+EnvironmentFile=-/usr/local/etc/sysconfig/gmond
+ExecStart=/usr/local/sbin/gmond --pid-file=/run/gmond.pid $GMOND_OPTIONS
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=5
+
+# Security hardening
+ProtectSystem=full
+ProtectHome=true
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/gmond.sysconfig
+++ b/systemd/gmond.sysconfig
@@ -1,0 +1,9 @@
+# Configuration file for gmond service
+# Place this file at /usr/local/etc/sysconfig/gmond
+
+# Path to gmond configuration file
+GMOND_OPTIONS="-c /usr/local/etc/ganglia/gmond.conf"
+
+# Add any additional options here
+# For example, to run in the foreground (useful for debugging):
+# GMOND_OPTIONS="-c /usr/local/etc/ganglia/gmond.conf -f"

--- a/systemd/install.sh
+++ b/systemd/install.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# 1. Copy the service file
+sudo cp gmond.service /etc/systemd/system/
+
+# 2. Create the sysconfig directory and copy the config
+sudo mkdir -p /usr/local/etc/sysconfig
+sudo cp gmond.sysconfig /usr/local/etc/sysconfig/gmond
+
+# 3. Create the ganglia config directory if it doesn't exist
+sudo mkdir -p /usr/local/etc/ganglia
+
+# 4. Generate a default gmond.conf if you don't have one
+/usr/local/sbin/gmond -t | sudo tee /usr/local/etc/ganglia/gmond.conf
+
+# 5.  Reload systemd and enable the service
+sudo systemctl daemon-reload
+sudo systemctl enable gmond
+sudo systemctl start gmond
+
+# 6. Check status
+sudo systemctl status gmond
+


### PR DESCRIPTION
Fixes to gmond.c so it builds under Debian Trixie, plus systemd files for /usr/local install.

Config script:
CPPFLAGS="-I/usr/include/tirpc" LDFLAGS="-ltirpc" ./configure --disable-python --with-libpcre=no 